### PR TITLE
:up: upgrade Zola to 0.19 and remove unusable toml props like date

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Install Zola
         run: |
-          wget -O zola.deb https://github.com/barnumbirr/zola-debian/releases/download/v0.16.1-1/zola_0.16.1-1_amd64_bullseye.deb
+          wget -O zola.deb https://github.com/barnumbirr/zola-debian/releases/download/v0.19.2-1/zola_0.19.2-1_amd64_bookworm.deb
           sudo dpkg -i zola.deb
       - name: checkout all the submodules
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://getzola.org.
 
 ## Miljø-krav
 
-Zola versjon >=0.13.0 (se zola-dokumentasjon instrukser)
+Zola versjon >=0.19.0 (se zola-dokumentasjon instrukser)
 
 ## Problemstillingen
 
@@ -34,7 +34,7 @@ oppdateres hver gang vi oppdaterer repoet.
 For å implementere dette, bruker vi GitHub actions som bygger den statiske siden
 ved merge til master, og rsync-er resultatet til server.
 
-Det er også en action for å validere endringer som er gjort ved opprettelse av 
+Det er også en action for å validere endringer som er gjort ved opprettelse av
 pull request til master, slik at vi ikke merger inn ødeleggende endringer.
 
 ## Kommandoer
@@ -52,4 +52,3 @@ side.
 - I skrivende stund bruker wikien en ferdiglaget utforming som heter adidoks.
   Den er å finne på zola sine nettsider. Følg instruksene gitt av adidoks for
   hvordan man legger til nytt innhold.
-

--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@ default_language = "en"
 compile_sass = true
 
 # Whether to generate a feed file for the site
-generate_feed = true
+generate_feeds = true
 
 # When set to "true", the generated HTML files are minified.
 minify_html = true

--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Authors"
 description = "The authurs of the blog articles."
-date = 2021-04-01T08:00:00+00:00
-updated = 2021-04-01T08:00:00+00:00
 draft = false
 
 # If add a new author page in this section, please add a new item,

--- a/content/authors/fribyte.md
+++ b/content/authors/fribyte.md
@@ -1,8 +1,6 @@
 +++
 title = "friByte"
 description = "Creator of friByte."
-date = 2001-02-24T08:50:45+00:00
-updated = 2001-02-24T08:50:45+00:00
 draft = false
 +++
 

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Docs"
 description = "The documents of the AdiDoks theme."
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 template = "docs/section.html"

--- a/content/docs/git/_index.md
+++ b/content/docs/git/_index.md
@@ -1,11 +1,8 @@
 +++
 title = "Git"
 description = "Versjonskontroll i friByte"
-date = 2022-03-16
-updated = 2022-03-16
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1
 draft = false
 +++
-

--- a/content/docs/hosting/_index.md
+++ b/content/docs/hosting/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Hosting"
 description = "Hvordan hosting fungerer"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/hosting/castopod.md
+++ b/content/docs/hosting/castopod.md
@@ -1,19 +1,22 @@
 +++
 title = "Castopod"
 description = "Åpen kildekode podcast-tjener"
-date = 2023-03-21T08:00:00+00:00
-updated = 2023-03-24T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 2
 draft = false
 +++
 
-friByte drifter sin egen podcast-tjener for å distribuere sin egen podcast, "Teknisk Tenketank". Til dette formålet bruker vi [Castopod](https://docs.castopod.org/) og er å finne på [podcast.fribyte.no](https://podcast.fribyte.no).
+friByte drifter sin egen podcast-tjener for å distribuere sin egen podcast,
+"Teknisk Tenketank". Til dette formålet bruker vi
+[Castopod](https://docs.castopod.org/) og er å finne på
+[podcast.fribyte.no](https://podcast.fribyte.no).
 
 ### Docker Compose filen
 
-Jeg brukte en docker-compose fil, basert på [den som Castopod gir oss som standard](https://docs.castopod.org/getting-started/docker.html#example-usage). Jeg endret den selvfølgelig slik at den er tilpasset våre miljøer. 
+Jeg brukte en docker-compose fil, basert på
+[den som Castopod gir oss som standard](https://docs.castopod.org/getting-started/docker.html#example-usage).
+Jeg endret den selvfølgelig slik at den er tilpasset våre miljøer.
 
 Her er Docker Compose filen som fungerte til slutt:
 
@@ -34,7 +37,7 @@ services:
       MYSQL_USER: castopod
       MYSQL_PASSWORD: lelelelelel
       CP_BASEURL: "http://podcast.fribyte.no"
-      CP_ANALYTICS_SALT: enellerannenstreng #laget med: tr -dc \!\#-\&\(-\[\]-\_a-\~ </dev/urandom | head -c 64 
+      CP_ANALYTICS_SALT: enellerannenstreng #laget med: tr -dc \!\#-\&\(-\[\]-\_a-\~ </dev/urandom | head -c 64
       CP_CACHE_HANDLER: redis
       CP_REDIS_HOST: redis
       CP_DATABASE_HOSTNAME: castopod-mariadb
@@ -115,41 +118,62 @@ networks:
   castopod-db:
 ```
 
-`ttt_mount` er et Docker volum som importerer filer som ligger lagret på Skrue (forklares nærmere litt under). Som du ser i definisjonen av volumet, brukes det SSHFS for å mounte filene. Passordet i denne konfigurasjonen blir ssh-passordet til `root`-brukeren på Konrad. 
+`ttt_mount` er et Docker volum som importerer filer som ligger lagret på Skrue
+(forklares nærmere litt under). Som du ser i definisjonen av volumet, brukes det
+SSHFS for å mounte filene. Passordet i denne konfigurasjonen blir ssh-passordet
+til `root`-brukeren på Konrad.
 
-En kan også benytte seg av ssh-nøkkel for verifisering. Det kan gjøres på denne måten:
+En kan også benytte seg av ssh-nøkkel for verifisering. Det kan gjøres på denne
+måten:
 
 ```yaml
 ttt_mount:
-    driver: vieux/sshfs:latest
-    driver_opts:
-      sshcmd: root@158.37.6.43:/dalar/podcast_ttt
-      IdentityFile: "/root/.ssh/ssh-key-file"
-      allow_other: ""
+  driver: vieux/sshfs:latest
+  driver_opts:
+    sshcmd: root@158.37.6.43:/dalar/podcast_ttt
+    IdentityFile: "/root/.ssh/ssh-key-file"
+    allow_other: ""
 ```
 
-Men i så tilfelle er det faktisk nødvendig at ssh-nøkkelen ligger i `/root/.ssh/..`. Hvis ikke, finner ikke `vieux/sshfs`-utvidelsen ssh-nøkkelen. [Kilde](https://github.com/vieux/docker-volume-sshfs/issues/58#issuecomment-447317661) 
+Men i så tilfelle er det faktisk nødvendig at ssh-nøkkelen ligger i
+`/root/.ssh/..`. Hvis ikke, finner ikke `vieux/sshfs`-utvidelsen ssh-nøkkelen.
+[Kilde](https://github.com/vieux/docker-volume-sshfs/issues/58#issuecomment-447317661)
 
-Utvidelsen installerte jeg ved å kjøre: `docker plugin install --grant-all-permissions vieux/sshfs` i Pengebingen. 
+Utvidelsen installerte jeg ved å kjøre:
+`docker plugin install --grant-all-permissions vieux/sshfs` i Pengebingen.
 
-Disse filene blir mountet direkte inn i Docker-containerne `castopod-app` og `castopod-web-server` fra Skrue. Det er viktig at filene er tilgjengelige i den respektive mappen i **begge** containerne.
+Disse filene blir mountet direkte inn i Docker-containerne `castopod-app` og
+`castopod-web-server` fra Skrue. Det er viktig at filene er tilgjengelige i den
+respektive mappen i **begge** containerne.
 
-Podcast-episodene som opprettes gjennom admin-panelet til podcast.fribyte.no, opprettes under `../media/podcasts/<navn-på-podcast>`. Derfor, når en episode nå lastes opp til gjennom admin-panelet, lagres den på Docker-volumet som er mountet fra Pengebingen inn i containerne. 
+Podcast-episodene som opprettes gjennom admin-panelet til podcast.fribyte.no,
+opprettes under `../media/podcasts/<navn-på-podcast>`. Derfor, når en episode nå
+lastes opp til gjennom admin-panelet, lagres den på Docker-volumet som er
+mountet fra Pengebingen inn i containerne.
 
 ### Importere lydfiler
 
-For å importere podcast-episodene som vi allerede hadde lagt ut gjennom Studentradioen i Bergen, brukte jeg Castopod sin innebygde importeringstjeneste. Den lastet inn alle episodene, samt metadata gjennom RSS-strømmen `https://podcast.srib.no/feed/254`. 
+For å importere podcast-episodene som vi allerede hadde lagt ut gjennom
+Studentradioen i Bergen, brukte jeg Castopod sin innebygde importeringstjeneste.
+Den lastet inn alle episodene, samt metadata gjennom RSS-strømmen
+`https://podcast.srib.no/feed/254`.
 
 ### Feilsøking
 
-I første omgang, fikk jeg en `404`-feil i nettleseren når nettsiden prøvde å laste inn lydfilene og andre medfølgende bildefiler. Dette var fordi jeg bare mountet volumet inn i `castopod-app`-containeren, og ikke `castopod-web-server`-containeren.
+I første omgang, fikk jeg en `404`-feil i nettleseren når nettsiden prøvde å
+laste inn lydfilene og andre medfølgende bildefiler. Dette var fordi jeg bare
+mountet volumet inn i `castopod-app`-containeren, og ikke
+`castopod-web-server`-containeren.
 
-Dette fikset jeg ved å mounte `ttt_mount` inn i `castopod-web-server` også. 
+Dette fikset jeg ved å mounte `ttt_mount` inn i `castopod-web-server` også.
 
 ### Kilder:
 
-[Castopod: Getting Started - Official Docker images](https://docs.castopod.org/getting-started/docker.html#example-usage), sist lest 24.03.2023.
+[Castopod: Getting Started - Official Docker images](https://docs.castopod.org/getting-started/docker.html#example-usage),
+sist lest 24.03.2023.
 
-[Mounting a SFTP (SSH) Share as a Volume in Docker-Compose](https://simplytim.io/mounting-a-sftp-ssh-share-as-a-volume-in-docker-compose/), sist lest 24.03.2023.
+[Mounting a SFTP (SSH) Share as a Volume in Docker-Compose](https://simplytim.io/mounting-a-sftp-ssh-share-as-a-volume-in-docker-compose/),
+sist lest 24.03.2023.
 
-[How do debug when password-less mount does not work](https://github.com/vieux/docker-volume-sshfs/issues/58#issuecomment-447317661), sist lest 24.03.2023.
+[How do debug when password-less mount does not work](https://github.com/vieux/docker-volume-sshfs/issues/58#issuecomment-447317661),
+sist lest 24.03.2023.

--- a/content/docs/hosting/oversikt.md
+++ b/content/docs/hosting/oversikt.md
@@ -1,8 +1,6 @@
 +++
 title = "Hosting - Sammendrag"
 description = "Vår hostingmetode"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 2

--- a/content/docs/hosting/passord-system.md
+++ b/content/docs/hosting/passord-system.md
@@ -1,8 +1,6 @@
 +++
 title = "Passord - Bitwarden"
 description = "Hvordan vi holder styr på passord"
-date = 2022-03-19T17:00:00+00:00
-updated = 2022-03-19T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 2

--- a/content/docs/innmelding/_index.md
+++ b/content/docs/innmelding/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Innmelding"
 description = "Nye medlemmer"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/innmelding/nytt_medlem.md
+++ b/content/docs/innmelding/nytt_medlem.md
@@ -1,8 +1,6 @@
 +++
 title = "Nytt medlem"
 description = "Hvordan innføre nytt medlem"
-date = 2022-02-23T08:00:00+00:00
-updated = 2024-04-16
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -160,7 +158,8 @@ Som en god øvelse i git, kan det nye medlemmet gjøre det selv. Dette er hva en
 gjør:
 
 1. Klon, eller dra ned, siste versjon av github-repoet vårt som heter `admin`.
-2. Åpne filen `medlemmer/legitimasjon/kortnummer` med ditt foretrukne tekstredigeringsprogram.
+2. Åpne filen `medlemmer/legitimasjon/kortnummer` med ditt foretrukne
+   tekstredigeringsprogram.
 3. Skriv inn kortnummeret ditt, lagre og lukk filen.
 4. Etabler forandringene og dytt dem til master.
 5. Leder må dermed sende mail til kortsenteret med en liste av kortnummerene, se

--- a/content/docs/instrukser/Glemt_passord_booking.md
+++ b/content/docs/instrukser/Glemt_passord_booking.md
@@ -1,8 +1,6 @@
 +++
 title = "Kunde Glemt Passord på Bookingsystem"
 description = ""
-date = 2022-03-16
-updated = 2022-03-16
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3
@@ -10,15 +8,14 @@ weight = 3
 
 Det har seg slik at noen kunder glemmer passordet på bookingsystemt sitt
 
-Ofte da kan de bytte selv ved å bruke sin egen admin bruker. Det går desverre ikke alltid da noen ganger glemmer de passordet på admin brukeren
+Ofte da kan de bytte selv ved å bruke sin egen admin bruker. Det går desverre
+ikke alltid da noen ganger glemmer de passordet på admin brukeren
 
 Vi har to kunder som vi leverer booking til pr.dags dato:
 
-[utstyr.bstv.no](utstyr.bstv.no)
-og
-[booking.srib.no](booking.srib.no)
+[utstyr.bstv.no](utstyr.bstv.no) og [booking.srib.no](booking.srib.no)
 
-Da må vi fikse. Det kan gjøres slik: 
+Da må vi fikse. Det kan gjøres slik:
 
 1. Gå inn på den respektive bookingsiden og finn "Logg inn" knappen
 1. Logg inn med vår bruker, passord er enten standard eller finnes på bitwarden

--- a/content/docs/instrukser/_index.md
+++ b/content/docs/instrukser/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Instrukser"
 description = "Samling av instrukser for diverse opprigg av tjenester"
-date = 2022-03-17T16:08:00+00:00
-updated = 2022-03-17T16:08:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/instrukser/aksess-til-filsystem-inni-vm-disk-image.md
+++ b/content/docs/instrukser/aksess-til-filsystem-inni-vm-disk-image.md
@@ -1,27 +1,43 @@
 +++
 title = "Aksess til filsystem inni VM Disk Image"
 description = "Aksess til filsystem inni VM Disk Image"
-date = 2024-02-11T16:00:00+00:00
-updated = 2024-02-11T16:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
 draft = false
 +++
 
-Hensikten med denne veiledningen er å gjøre det mulig for friBytere å lese data som hører til VM-er som av en vilkårlig grunn ikke kan nås og leses fra innsiden av maskinen. Dette gjøres på hosten som inneholder VM-en, som fører til at ingen dataoverføring som blir nettverks- eller lagringskompliserende er nødvendig.
+Hensikten med denne veiledningen er å gjøre det mulig for friBytere å lese data
+som hører til VM-er som av en vilkårlig grunn ikke kan nås og leses fra innsiden
+av maskinen. Dette gjøres på hosten som inneholder VM-en, som fører til at ingen
+dataoverføring som blir nettverks- eller lagringskompliserende er nødvendig.
 
-Diskbilder i Proxmox vises som litt spesielle filer, tilsynelatende symlinker. Jeg har ikke klart å se hva som ligger på andre siden, og filen hevder den er 0 bytes stor. Disse filene kan du oppdage lokasjon til gjennom følgende kommando: `pvesm path [storage pool]:[vm-disk-id]`, for eksempel: `pvesm path basseng:vm-531-disk-0`.
+Diskbilder i Proxmox vises som litt spesielle filer, tilsynelatende symlinker.
+Jeg har ikke klart å se hva som ligger på andre siden, og filen hevder den er 0
+bytes stor. Disse filene kan du oppdage lokasjon til gjennom følgende kommando:
+`pvesm path [storage pool]:[vm-disk-id]`, for eksempel:
+`pvesm path basseng:vm-531-disk-0`.
 
-Ofte vet Proxmox om de forskjellige partisjonene på disse diskbildene. Da kommer de opp på samme lokasjon returnert av kommandoen, som `disknavn-partX` der X er partisjonsnummeret. Erfaringsmessig er det partisjon nummer 1 som er root-partisjonen på VM-er klonet fra vår base.
+Ofte vet Proxmox om de forskjellige partisjonene på disse diskbildene. Da kommer
+de opp på samme lokasjon returnert av kommandoen, som `disknavn-partX` der X er
+partisjonsnummeret. Erfaringsmessig er det partisjon nummer 1 som er
+root-partisjonen på VM-er klonet fra vår base.
 
-Gjennom kommandoen `losetup` kan så dette bildet mountes som en "loop device". Dette gjør at du kan bruke standardverktøy (feks. fdisk) for å jobbe med disken, som om det var en fysisk disk plassert i serveren:
-- For å gjøre et diskbilde til en loop device: `losetup -f -P [path returnert]` feks. `losetup -f -P /dev/zvol/basseng/vm-531-disk-0-part1`
+Gjennom kommandoen `losetup` kan så dette bildet mountes som en "loop device".
+Dette gjør at du kan bruke standardverktøy (feks. fdisk) for å jobbe med disken,
+som om det var en fysisk disk plassert i serveren:
+
+- For å gjøre et diskbilde til en loop device: `losetup -f -P [path returnert]`
+  feks. `losetup -f -P /dev/zvol/basseng/vm-531-disk-0-part1`
 - For å liste loop devices aktive: `losetup -l`
-- For å deaktivere en loop device (påvirker ikke diskbildet): `losetup -d /dev/loopX`.
+- For å deaktivere en loop device (påvirker ikke diskbildet):
+  `losetup -d /dev/loopX`.
 
-Til slutt, mount filsystemet: `mount --mkdir /dev/loopX /mnt/my-vm-disk`. Du finner nå (forhåpentligvis) roten av filsystemet til VM-en på `/mnt/my-vm-disk`.
+Til slutt, mount filsystemet: `mount --mkdir /dev/loopX /mnt/my-vm-disk`. Du
+finner nå (forhåpentligvis) roten av filsystemet til VM-en på `/mnt/my-vm-disk`.
 
 ## Om du må klone disken
-Bruk `dd if=[path returnert av proxmox-kommandoen] of=~/my-disk-image.raw`. Dette kan så mountes om en disk til en VM. For å endre størrelse (øke med 10GiB): `qemu-img resize my-disk-image.raw +10G`.
 
+Bruk `dd if=[path returnert av proxmox-kommandoen] of=~/my-disk-image.raw`.
+Dette kan så mountes om en disk til en VM. For å endre størrelse (øke med
+10GiB): `qemu-img resize my-disk-image.raw +10G`.

--- a/content/docs/instrukser/brannmur.md
+++ b/content/docs/instrukser/brannmur.md
@@ -1,8 +1,6 @@
 +++
 title = "Brannmur"
 description = "Åpner porter i brannmur"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/docker-hosting-pengebingen.md
+++ b/content/docs/instrukser/docker-hosting-pengebingen.md
@@ -1,8 +1,6 @@
 +++
 title = "Docker-hosting Pengebingen"
 description = "Hvordan hoste docker containere"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-03-14
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/domener.md
+++ b/content/docs/instrukser/domener.md
@@ -1,8 +1,6 @@
 +++
 title = "Domener"
 description = "Hvordan sette opp domener"
-date = 2022-02-06T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -13,7 +11,9 @@ draft = false
 
 1. Ta turen til bestemor `ssh root@bestemor.s.fribyte.no`
 2. `ssh fribyte@ns1.fribyte.no`
-3. Oppdater passende domene ved å kjøre scriptet `./update_zone.sh fribyte.no` (bruk noe annet enn fribyte.no for å redigere domener som ikke er .fribyte.no)
+3. Oppdater passende domene ved å kjøre scriptet `./update_zone.sh fribyte.no`
+   (bruk noe annet enn fribyte.no for å redigere domener som ikke er
+   .fribyte.no)
 4. Legg til passende entry
 5. Oppdater serial `{år}{måned}{dato}{hh}` -> `2022020618`
 

--- a/content/docs/instrukser/full-disk.md
+++ b/content/docs/instrukser/full-disk.md
@@ -1,8 +1,6 @@
 +++
 title = "Fikse 100% full disk"
 description = "Fikse 100% full disk"
-date = 2022-03-27T08:00:00+00:00
-updated = 2022-03-27T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/ha_setup.md
+++ b/content/docs/instrukser/ha_setup.md
@@ -1,8 +1,6 @@
 +++
 title = "High availability for VM"
 description = ""
-date = 2022-03-16
-updated = 2022-03-16
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3

--- a/content/docs/instrukser/kubernetes.md
+++ b/content/docs/instrukser/kubernetes.md
@@ -1,8 +1,6 @@
 +++
 title = "Kubernetes"
 description = "Kubernetes"
-date = 2023-12-05T15:51:00+00:00
-updated = 2023-12-05T15:51:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/migrere-database.md
+++ b/content/docs/instrukser/migrere-database.md
@@ -1,65 +1,84 @@
 +++
 title = "Database-migrering"
 description = "En forklaring av hvordan jeg migrerte alle databasene fra Donald (ubuntu 14.04) til en VM på Konrad (Ubuntu 22.02)."
-date = 2023-03-03
-updated = 2023-03-21
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3
 +++
 
-friByte drifter SQL-databaser for klienter. Dette har vi forsåvidt alltid gjort, 
-men de nye databasene vi drifter ligger på VM-ene i ProxMox. Tidligere lå alle databasene 
-på en maskintjener som heter Donald. Siden mange av tidligere klienter som brukte de databasene aktivt
-ikke lenger bruker dem, har databasen stått til forfall.
+friByte drifter SQL-databaser for klienter. Dette har vi forsåvidt alltid gjort,
+men de nye databasene vi drifter ligger på VM-ene i ProxMox. Tidligere lå alle
+databasene på en maskintjener som heter Donald. Siden mange av tidligere
+klienter som brukte de databasene aktivt ikke lenger bruker dem, har databasen
+stått til forfall.
 
-Vi har derfor nylig (06.03.2023) flyttet alle databasene over til én VM i ProxMox-clusteret, med det intuitive navnet "database". På den måten garanterer vi for regelmessige sikkerhetskopier i tillegg til å modernisere databasen.
+Vi har derfor nylig (06.03.2023) flyttet alle databasene over til én VM i
+ProxMox-clusteret, med det intuitive navnet "database". På den måten garanterer
+vi for regelmessige sikkerhetskopier i tillegg til å modernisere databasen.
 
 ### Overføre databasene
 
 1. Inne på Donald: `mysqldump --all-databases --replace --events > donald.sql`
-2. Inne på Donald: `rsync -r -v --info=progress2 donald.sql root@158.37.6.28:/root`
-3. Inne på Konrad: `rsync -r -v --info=progress2 /root/donald.sql fribyte@158.37.6.37:/home/fribyte`
-4. Inne på VM-en: `sudo apt install pv`*
+2. Inne på Donald:
+   `rsync -r -v --info=progress2 donald.sql root@158.37.6.28:/root`
+3. Inne på Konrad:
+   `rsync -r -v --info=progress2 /root/donald.sql fribyte@158.37.6.37:/home/fribyte`
+4. Inne på VM-en: `sudo apt install pv`\*
 5. Inne i mysql på VM-en: `SET GLOBAL innodb_strict_mode=OFF;`
 6. Inne på VM-en: `pv donald.sql | sudo mysql -u root -p`
 7. Inne på VM-en: `sudo service mysql stop`
 8. Inne på VM-en: `sudo mysqld --upgrade=FORCE`
 9. Inne på VM-en: `sudo service mysql start`
 
-*_"pv" står for "pipeviewer" og er bare for å kunne se fremgangen på overføringen._
+\*_"pv" står for "pipeviewer" og er bare for å kunne se fremgangen på
+overføringen._
 
-Når alt dette var gjennomført, ble innloggings-informasjonen og bruker-informasjonen fra sql-dumpen overført inn i den ferske mysql-serveren. Hvilket betyr at en kan logge inn i denne databasen med de samme brukerne som den gamle databasen.
+Når alt dette var gjennomført, ble innloggings-informasjonen og
+bruker-informasjonen fra sql-dumpen overført inn i den ferske mysql-serveren.
+Hvilket betyr at en kan logge inn i denne databasen med de samme brukerne som
+den gamle databasen.
 
-Men rettighetene fungerte ikke helt skikkelig, så jeg måtte også endre root-passordet, for å få full admin-tilgang.
+Men rettighetene fungerte ikke helt skikkelig, så jeg måtte også endre
+root-passordet, for å få full admin-tilgang.
 
 ### Slik endret jeg root-passordet
 
-1. Inne på VM-en: `sudo vim /etc/mysql/mysql.conf.d/mysqld.cnf` og legg til `skip-grant-tables` under `[mysqld]`. Lagre og lukk.
+1. Inne på VM-en: `sudo vim /etc/mysql/mysql.conf.d/mysqld.cnf` og legg til
+   `skip-grant-tables` under `[mysqld]`. Lagre og lukk.
 2. Inne på VM-en: `sudo service mysl restart`
 3. Inne på VM-en: `sudo mysql -u root`
 4. Inne i mysql på VM-en: `FLUSH PRIVILEGES;`
-5. Inne i mysql på VM-en: `ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'lololol';` 
+5. Inne i mysql på VM-en:
+   `ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'lololol';`
 
-Om du nå fjerner `skip-grant-tables` fra `/etc/mysql/mysql.conf.d/mysqld.cnf`, og kjører `sudo service mysql restart`, kan du nå logge inn som `root` med passord: `lololol`.
+Om du nå fjerner `skip-grant-tables` fra `/etc/mysql/mysql.conf.d/mysqld.cnf`,
+og kjører `sudo service mysql restart`, kan du nå logge inn som `root` med
+passord: `lololol`.
 
-Etter dette, kunne jeg endre passord på brukerne som kom med `donald.sql`. Jeg gjorde følgende:
+Etter dette, kunne jeg endre passord på brukerne som kom med `donald.sql`. Jeg
+gjorde følgende:
 
 1. Inne på VM-en: `sudo mysql -u -p` _skriv inn passord_
-2. Inne i mysql på VM-en: `ALTER USER 'digas'@'%' IDENTIFIED WITH mysql_native_password BY 'lololol';`**
+2. Inne i mysql på VM-en:
+   `ALTER USER 'digas'@'%' IDENTIFIED WITH mysql_native_password BY 'lololol';`\*\*
 3. Inne i mysql på VM-en: `FLUSH PRIVILEGES;`
 
-**_"digas" er database-brukeren til SRiB for DigaSystem-programmet deres. "%" betyr hvilken som helst host_
+\*\*_"digas" er database-brukeren til SRiB for DigaSystem-programmet deres. "%"
+betyr hvilken som helst host_
 
 ### Full disk ila. overføring
 
-Denne prosessen tok litt tid, og trengte en god del mer lagringsplass på VM-en enn jeg forventet. Så overføringen kræsjet flere ganger på grunn av mangel på plass. 
+Denne prosessen tok litt tid, og trengte en god del mer lagringsplass på VM-en
+enn jeg forventet. Så overføringen kræsjet flere ganger på grunn av mangel på
+plass.
 
-SQL-dumpen, donald.sql, tok opp 5.1 GB med lagring, men når den var overført til mysql-serveren, tok databasen opp 12 GB. Så, til sammen 17.1 GB. 
+SQL-dumpen, donald.sql, tok opp 5.1 GB med lagring, men når den var overført til
+mysql-serveren, tok databasen opp 12 GB. Så, til sammen 17.1 GB.
 
 Så dette er hvordan jeg håndterte full disk.
 
-1. Inne på VM-en: `sudo apt-get purge mysql-server mysql-client mysql-common mysql-server-core-* mysql-client-core-* && sudo rm -rf /etc/mysql /var/lib/mysql`
+1. Inne på VM-en:
+   `sudo apt-get purge mysql-server mysql-client mysql-common mysql-server-core-* mysql-client-core-* && sudo rm -rf /etc/mysql /var/lib/mysql`
 2. Inne på VM-en: `sudo apt install mysql-server -y`
 3. Inne i mysql: `SET GLOBAL innodb_strict_mode=OFF;`
 4. Tildel VM-en mer lagringsplass. Dette kan gjøres i web GUI-en til ProxMox.
@@ -67,7 +86,8 @@ Så dette er hvordan jeg håndterte full disk.
 
 ### Åpne for eksterne tilkoblinger
 
-For at eksterne maskiner skal kunne koble seg til, må vi skrive dette inn i konfigureringen.
+For at eksterne maskiner skal kunne koble seg til, må vi skrive dette inn i
+konfigureringen.
 
 1. Inne på VM-en: `sudo vim /etc/mysql/mysql.conf.d/mysqld.cnf`
 2. Endre:
@@ -91,35 +111,48 @@ bind-address            = *
 mysqlx-bind-address     = *
 ```
 
-Da åpner du for for alle IP-adresser. Både IPv4 oggit push -u origin branch IPv6.
+Da åpner du for for alle IP-adresser. Både IPv4 oggit push -u origin branch
+IPv6.
 
 ### Åpne for flere samtidige tilkoblinger
 
-podcast.srib.no hadde et problem med at nye podcast-episoder ikke dukket opp på ulike tredjepart-plattformer. Feilmeldingen som dukket opp i Django-koden var: `MySQLdb._exceptions.OperationalError: (1040, 'Too many connections')`.
+podcast.srib.no hadde et problem med at nye podcast-episoder ikke dukket opp på
+ulike tredjepart-plattformer. Feilmeldingen som dukket opp i Django-koden var:
+`MySQLdb._exceptions.OperationalError: (1040, 'Too many connections')`.
 
-Dette betyr at MySQL-tjeneren ikke tillater nok samtidige tilkoblinger, og nekter dermed alle andre enn de XXX første tilkoblingene. 
+Dette betyr at MySQL-tjeneren ikke tillater nok samtidige tilkoblinger, og
+nekter dermed alle andre enn de XXX første tilkoblingene.
 
 For å fikse dette, gjør en følgende:
 
 1. Inne på VM-en: `sudo vim /etc/mysql/mysql.conf.d/mysqld.cnf`.
 2. Finn `max_connections = XXXX`.
-3. Endre `max_connections` til å være noe mellom 1 og 10'000. (jo høyere tall, jo flere tilkoblinger tillater du).
+3. Endre `max_connections` til å være noe mellom 1 og 10'000. (jo høyere tall,
+   jo flere tilkoblinger tillater du).
 4. Lagre filen og restart MySQL-tjenesten med `sudo service mysql restart`.
 
-Om du får en feilmelding på steg 4, er det godt mulig at det er en syntaks-feil i `/etc/mysql/mysql.conf.d/mysqld.cnf`.
+Om du får en feilmelding på steg 4, er det godt mulig at det er en syntaks-feil
+i `/etc/mysql/mysql.conf.d/mysqld.cnf`.
 
-For å sjekke om forandringen har manifestert seg, kan du skrive `show variables like "max_connections";` etter at du har logget inn i MySQL-tjeneren.
+For å sjekke om forandringen har manifestert seg, kan du skrive
+`show variables like "max_connections";` etter at du har logget inn i
+MySQL-tjeneren.
 
-Alternativt, kan du også skrive `set global max_connections = 5000;` mens du er logget inn i MySQL-tjeneren
+Alternativt, kan du også skrive `set global max_connections = 5000;` mens du er
+logget inn i MySQL-tjeneren
 
 ### Kilder:
 
-[MySQL: Error Code: 1118 Row size too large (> 8126).](https://stackoverflow.com/a/37076100), sist lest 06.03.23
+[MySQL: Error Code: 1118 Row size too large (> 8126).](https://stackoverflow.com/a/37076100),
+sist lest 06.03.23
 
-[How to fix ERROR 1726 (HY000): Storage engine 'MyISAM' does not support system tables](https://stackoverflow.com/a/55838493), sist lest 06.03.23
+[How to fix ERROR 1726 (HY000): Storage engine 'MyISAM' does not support system tables](https://stackoverflow.com/a/55838493),
+sist lest 06.03.23
 
 [Change root password](https://stackoverflow.com/a/58964143), sist lest 06.03.23
 
-[Mysql 8 bind-address syntax](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_bind_address), sist lest 06.03.23
+[Mysql 8 bind-address syntax](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_bind_address),
+sist lest 06.03.23
 
-[How to increase MySQL connections(max_connections)](https://stackoverflow.com/a/22297829), sist lest 21.03.23
+[How to increase MySQL connections(max_connections)](https://stackoverflow.com/a/22297829),
+sist lest 21.03.23

--- a/content/docs/instrukser/ny-vm-med-wordpress.md
+++ b/content/docs/instrukser/ny-vm-med-wordpress.md
@@ -1,8 +1,6 @@
 +++
 title = "Ny VM med Wordpress"
 description = "Ny VM med Wordpress"
-date = 2023-03-29T08:00:00+00:00
-updated = 2023-03-29
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/ny-vm.md
+++ b/content/docs/instrukser/ny-vm.md
@@ -1,8 +1,6 @@
 +++
 title = "Ny VM"
 description = "Ny VM"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-03-14
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -26,10 +24,12 @@ before starting. The setup can be found [here](../ha-setup)
 1. Brukernavn: fribyte
 1. Passord: det vanlige.
 1. Definer ip under "cloud init"
-   - Finn ledig ip i [/docs/nettverk/nettverk-oversikt](/docs/nettverk/nettverk-oversikt)
+   - Finn ledig ip i
+     [/docs/nettverk/nettverk-oversikt](/docs/nettverk/nettverk-oversikt)
    - Alternativt må du gjøre litt pinging rundt om kring på 158.37.6.xx for å
      finne en ledig ip
-1. Sjekk at SSH public key er definert, hvis dette ikke er tilfellet kan de kopieres fra en annen VM.
+1. Sjekk at SSH public key er definert, hvis dette ikke er tilfellet kan de
+   kopieres fra en annen VM.
 1. Start vm og vent på at den er klar.
 1. Oppdater `~/.ssh/config` på Konrad til å inkludere en peker til nye vm for
    lettere ssh'ing. Alternativt kan man legge inn en DNS peker på kladden slik

--- a/content/docs/instrukser/proxmox-backup.md
+++ b/content/docs/instrukser/proxmox-backup.md
@@ -1,8 +1,6 @@
 +++
 title = "Proxmox VM backup"
 description = "Sette opp backup av VM'er i Proxmox"
-date = 2022-10-18T08:00:00+00:00
-updated = 2022-10-18T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/skrue-info-and-zfs-replace-disk.md
+++ b/content/docs/instrukser/skrue-info-and-zfs-replace-disk.md
@@ -1,8 +1,6 @@
 +++
 title = "Skrue Info + Replace disk ZFS"
 description = "Info about Skrue and how to replace a disk in ZFS"
-date = 2022-09-22T08:00:00+00:00
-updated = 2022-09-22
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/instrukser/uptime-kuma.md
+++ b/content/docs/instrukser/uptime-kuma.md
@@ -1,16 +1,18 @@
 +++
 title = "Uptime Kuma"
 description = "Hvordan legge til en ny tjeneste i uptime kuma"
-date = 2023-03-30
-updated = 2022-04-18
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3
 +++
 
-#friByte bruker [Uptime Kuma](https://github.com/louislam/uptime-kuma) for holde oversikt over oppetiden til tjenestene vi drifter. Den er å finne på [uptime.fribyte.no](https://uptime.fribyte.no). Du logger inn på admin-panelet ved å gå til [uptime.fribyte.no/dashboard](https://uptime.fribyte.no/dashboard).
+#friByte bruker [Uptime Kuma](https://github.com/louislam/uptime-kuma) for holde
+oversikt over oppetiden til tjenestene vi drifter. Den er å finne på
+[uptime.fribyte.no](https://uptime.fribyte.no). Du logger inn på admin-panelet
+ved å gå til [uptime.fribyte.no/dashboard](https://uptime.fribyte.no/dashboard).
 
-Denne tjenesten er koblet opp mot mattermost gjennom "Mattermost notification"-funksjonen til uptime kuma. 
+Denne tjenesten er koblet opp mot mattermost gjennom "Mattermost
+notification"-funksjonen til uptime kuma.
 
 ### Hvordan legge til en ny tjeneste
 
@@ -19,8 +21,9 @@ Denne tjenesten er koblet opp mot mattermost gjennom "Mattermost notification"-f
 3. Fyll inn følgende:
 
 - Vennlig navn: Hva tjenesten skal hete i listen
-- Forsøk: Hvor mange ganger uptime skal prøve på nytt før den sier ifra om en feil
-- Certificate Expiry Notification: Sier ifra om letsencrypt har gått ut. 
+- Forsøk: Hvor mange ganger uptime skal prøve på nytt før den sier ifra om en
+  feil
+- Certificate Expiry Notification: Sier ifra om letsencrypt har gått ut.
 - Oppetidroboten: om denne tjenesten skal sende varsel til mattermost
 
 _Det finnes andre innstillinger også, men dette er minimum du trenger_

--- a/content/docs/instrukser/wordpress.md
+++ b/content/docs/instrukser/wordpress.md
@@ -1,8 +1,6 @@
 +++
 title = "Kom i gang med Wordpress"
 description = "Navigasjon og redigering i Wordpress"
-date = 2024-02-20T08:00:00+00:00
-updated = 2024-02-20
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -15,22 +13,21 @@ draft = false
 2. Bruk brukernavn og passord for å få tilgang til Wordpress Dashboard.
 
 #### Installere og endre tema.
+
 1. Trykk på "Appearance", deretter velg submeny "Themes".
 2. Trykk på "Add new theme" for å legge til et nytt tema.
-    - Her ligger det flere tusen ferdiglagde temaer.
+   - Her ligger det flere tusen ferdiglagde temaer.
 3. Hold over valgt tema og velg "Install".
 4. Nå vil det installerte temaet ligge under "Appearance/Themes".
 5. Hold over det nye temaet og velg "Activate".
 
 #### Redigering.
+
 1. Trykk på "Appearance", deretter velg submeny "Editor".
    - Her har du mulighet til å legge til elementer til siden.
-2. Trykk på bildet av nettsiden. Her har du mulighet til å legge til, redigere eller slette elementer på siden.
+2. Trykk på bildet av nettsiden. Her har du mulighet til å legge til, redigere
+   eller slette elementer på siden.
    - Trykk på "+" tegnet øverst til høyre for å legge til et nytt element.
-   - Hold over element for å få opp en meny, denne brukes for å redigere eller slette innholdet av elementet.
+   - Hold over element for å få opp en meny, denne brukes for å redigere eller
+     slette innholdet av elementet.
    - Trykk på tekst for å redigere teksten i feltet.
-
-
-
-
-

--- a/content/docs/kommunikasjon/_index.md
+++ b/content/docs/kommunikasjon/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Kommunikasjon"
 description = "Kommunikasjon i friByte"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/kommunikasjon/oversikt.md
+++ b/content/docs/kommunikasjon/oversikt.md
@@ -1,8 +1,6 @@
 +++
 title = "Kommunikasjon - Sammendrag"
 description = "Våre kommunikasjonskanaler"
-date = 2022-01-18T08:00:00+00:00
-updated = 2024-01-18T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 2

--- a/content/docs/kunder/_index.md
+++ b/content/docs/kunder/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Kunder"
 description = "Oversikt over kunder og hva vi drifter for de"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/kunder/bergen-realistforening.md
+++ b/content/docs/kunder/bergen-realistforening.md
@@ -1,8 +1,6 @@
 +++
 title = "Bergen Realistforening"
 description = "Bergen Realistforening"
-date = 2023-03-21T15:51:00+00:00
-updated = 2023-03-21T15:51:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -32,8 +30,8 @@ har sluttet å virke. En naturlig aksjonsliste blir da:
 
 Sist Oppdatert: 21.03.2023
 
-| Domenenavn             | Kort forklaring            |
-| ---------------------- | -------------------------- |
+| Domenenavn                     | Kort forklaring            |
+| ------------------------------ | -------------------------- |
 | [rf.uib.no](https://rf.uib.no) | Hovedside, vertet på Pluto |
 
 ## Kontaktinformasjon

--- a/content/docs/kunder/boskonf.md
+++ b/content/docs/kunder/boskonf.md
@@ -1,8 +1,6 @@
 +++
 title = "Boskonf"
 description = "Bergen Open Source"
-date = 2024-01-09T15:51:00+00:00
-updated = 2024-01-09T15:51:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -25,6 +23,6 @@ til Pengebingen via SSH.
 
 Sist Oppdatert: 09.01.2024
 
-| Domenenavn               | Kort forklaring |
-| ------------------------ | --------------- |
+| Domenenavn                       | Kort forklaring |
+| -------------------------------- | --------------- |
 | [boskonf.no](https://boskonf.no) | Hovedside       |

--- a/content/docs/kunder/bstv.md
+++ b/content/docs/kunder/bstv.md
@@ -1,8 +1,6 @@
 +++
 title = "Bergen Student-TV"
 description = "Informasjon om BSTV"
-date = 2022-03-06T15:51:00+00:00
-updated = 2022-03-06T15:51:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -24,8 +22,8 @@ tilbake enda, men har forespurt om beslutningen deres.
 
 Sist Oppdatert: 06.03.2022
 
-| Domenenavn                       | Kort forklaring                |
-| -------------------------------- | ------------------------------ |
+| Domenenavn                               | Kort forklaring                |
+| ---------------------------------------- | ------------------------------ |
 | [bstv.no](https://bstv.no)               | Wordpress-hovedside            |
 | [intern.bstv.no](https://intern.bstv.no) | Fungerer ikke, 503-feilmelding |
 | [utstyr.bstv.no](https://utstyr.bstv.no) | Meeting Room Booking System    |

--- a/content/docs/kunder/kunder.md
+++ b/content/docs/kunder/kunder.md
@@ -1,8 +1,6 @@
 +++
 title = "Kunder - Sammendrag"
 description = "Oversikt over kunder og hva vi drifter for de"
-date = 2022-01-18T08:00:00+00:00
-updated = 2024-02-22T00:13:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 2
@@ -72,4 +70,4 @@ Linjeforeningen for geologistudentene ved UiB
 
 - Nettside verting
   - www.rootlinjeforening.no
-  - *.rootlinjeforening.no
+  - \*.rootlinjeforening.no

--- a/content/docs/kunder/phonofestivalen.md
+++ b/content/docs/kunder/phonofestivalen.md
@@ -1,8 +1,6 @@
 +++
 title = "Phonofestivalen"
 description = "Informasjon om Phonofestivalen"
-date = 2022-03-06T16:36:00+00:00
-updated = 2022-03-06T16:36:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -26,8 +24,8 @@ har signert enda. Vi avventer i skrivende stund signaturen deres.
 
 Sist oppdatert: 06.03.2022
 
-| Domenenavn                               | Kort forklaring                                |
-| ---------------------------------------- | ---------------------------------------------- |
+| Domenenavn                                       | Kort forklaring                                |
+| ------------------------------------------------ | ---------------------------------------------- |
 | [Phonofestivalen.no](https://phonofestivalen.no) | Wordpress-hovedside; er for øyeblikket parkert |
 
 ### Kontaktinformasjon

--- a/content/docs/kunder/root.md
+++ b/content/docs/kunder/root.md
@@ -1,35 +1,41 @@
 +++
 title = "Root Linjeforening"
 description = "Informasjon om BSTV"
-date = 2024-02-21T23:52:00+00:00
-updated = 2024-02-21T23:52:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
 draft = false
 +++
 
-Root Linjeforening er en studentorganisasjon ved Høgskulen på Vestlandet for Data- og IT-studenter.
+Root Linjeforening er en studentorganisasjon ved Høgskulen på Vestlandet for
+Data- og IT-studenter.
 
-Organisasjonen arrangerer blant annet sosiale arrangementer og arbeider for å knytte studentene nærmere næringslivet gjennom bedriftspresentasjoner. Arrangementer blir organisert gjennom skoleåret, med formål om å skape bekjentskaper på tvers av klassetrinn og fremme et godt studentmiljø ved instituttet. Programmet varierer fra temafester til quizer, og samarbeid har også blitt inngått med andre organisasjoner.
+Organisasjonen arrangerer blant annet sosiale arrangementer og arbeider for å
+knytte studentene nærmere næringslivet gjennom bedriftspresentasjoner.
+Arrangementer blir organisert gjennom skoleåret, med formål om å skape
+bekjentskaper på tvers av klassetrinn og fremme et godt studentmiljø ved
+instituttet. Programmet varierer fra temafester til quizer, og samarbeid har
+også blitt inngått med andre organisasjoner.
 
-Nettsiden www.rootlinjeforening.no og mulige nettsider *.rootlinjeforening.no er laget av deres egen IT-avdeling. Vi hoster da deres nettsider og hovednettsiden er deployed med docker.
+Nettsiden www.rootlinjeforening.no og mulige nettsider \*.rootlinjeforening.no
+er laget av deres egen IT-avdeling. Vi hoster da deres nettsider og
+hovednettsiden er deployed med docker.
 
 ### Relevante domener
 
 Sist Oppdatert: 21.02.2024
 
-| Domenenavn                       | Kort forklaring                |
-| -------------------------------- | ------------------------------ |
-| [www.rootlinjeforening.no](https://www.rootlinjeforening.no)               | NextJS-hovedside            |
-| [*.rootlinjeforening.no](#)               | Mulige nettsider            |
+| Domenenavn                                                   | Kort forklaring  |
+| ------------------------------------------------------------ | ---------------- |
+| [www.rootlinjeforening.no](https://www.rootlinjeforening.no) | NextJS-hovedside |
+| [\*.rootlinjeforening.no](#)                                 | Mulige nettsider |
 
 ### Kontaktinformasjon
 
 Sist Oppdatert: 21.02.2024
 
-| Stilling           | Navn                 | Nummer     | E-adresse                  |
-| ------------------ | -------------------- | ---------- | -------------------------- |
-| Styreleder         | Nick James Hipol      | I/T | 676663@stud.hvl.no    |
-| Nestleder         | Kristina Dahlgren    | I/T | 142943@stud.hvl.no    |
-| IT-ansvarlig | Simen Strømsnes | I/T | 676624@stud.hvl.no       |
+| Stilling     | Navn              | Nummer | E-adresse          |
+| ------------ | ----------------- | ------ | ------------------ |
+| Styreleder   | Nick James Hipol  | I/T    | 676663@stud.hvl.no |
+| Nestleder    | Kristina Dahlgren | I/T    | 142943@stud.hvl.no |
+| IT-ansvarlig | Simen Strømsnes   | I/T    | 676624@stud.hvl.no |

--- a/content/docs/kunder/studentparlamentet.md
+++ b/content/docs/kunder/studentparlamentet.md
@@ -1,8 +1,6 @@
 +++
 title = "Studentparlamentet"
 description = "Informasjon om Studentparlamentet"
-date = 2022-03-16T16:36:00+00:00
-updated = 2022-03-16T16:36:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/kunder/studentradioen.md
+++ b/content/docs/kunder/studentradioen.md
@@ -1,8 +1,6 @@
 +++
 title = "Studentradioen i Bergen"
 description = "Informasjon om SRiB"
-date = 2022-03-06T14:00:00+00:00
-updated = 2022-03-06T14:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -27,18 +25,18 @@ neste år.
 
 ## Tjenester
 
-| Tjeneste og domenenavn | Kort Forklaring |
-| ---------------------- | --------------- |
-| [srib.no](/docs/produksjon/srib-no) | Wordpress-hovedside |
-| [booking.srib.no](/docs/produksjon/booking-srib-no) | Meeting Room Booking System - for å reservere rom |
-| [skjema.srib.no](/docs/produksjon/skjema-srib-no) | LimeSurvey - for skreddersydde spørreundersøkelser |
-| [wiki.srib.no](/docs/produksjon/wiki-srib-no) | Statisk side laget med Hugo. bruker Docsy-themet. |
+| Tjeneste og domenenavn                              | Kort Forklaring                                                                                                                                                                                               |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [srib.no](/docs/produksjon/srib-no)                 | Wordpress-hovedside                                                                                                                                                                                           |
+| [booking.srib.no](/docs/produksjon/booking-srib-no) | Meeting Room Booking System - for å reservere rom                                                                                                                                                             |
+| [skjema.srib.no](/docs/produksjon/skjema-srib-no)   | LimeSurvey - for skreddersydde spørreundersøkelser                                                                                                                                                            |
+| [wiki.srib.no](/docs/produksjon/wiki-srib-no)       | Statisk side laget med Hugo. bruker Docsy-themet.                                                                                                                                                             |
 | [podcast.srib.no](/docs/produksjon/podcast-srib-no) | RSS-generator skrevet i Django. Brukes for å lage RSS-strømmer til hver podcast. Kildekode: https://github.com/srib-dev/podkast.srib.no. Et docker image er bygget i srib-radio vm med secrets og kjører der. |
-| [bilder.srib.no](/docs/produksjon/bilder-srib-no) | PhotoPrism - bildegalleri for alle bilder radioen vil ta vare på |
-| [radio.srib.no](/docs/produksjon/radio-srib-no) | AzuraCast - Nettradiotjeneste bygget på IceCast og LiquidSoap |
-| [lytt.srib.no](/docs/produksjon/lytt-srib-no) | Statisk nettside som serverer en ferdiglaget iframe-tag fra AzuraCast |
-| [Intern.srib.no](/docs/produksjon/intern-srib-no) | Dokumentdelingstjeneste brukt av produsentene. deres |
-| Database for digas | Digas er radiospesifikk programvare. Vertet i VM med navn "Database" |
+| [bilder.srib.no](/docs/produksjon/bilder-srib-no)   | PhotoPrism - bildegalleri for alle bilder radioen vil ta vare på                                                                                                                                              |
+| [radio.srib.no](/docs/produksjon/radio-srib-no)     | AzuraCast - Nettradiotjeneste bygget på IceCast og LiquidSoap                                                                                                                                                 |
+| [lytt.srib.no](/docs/produksjon/lytt-srib-no)       | Statisk nettside som serverer en ferdiglaget iframe-tag fra AzuraCast                                                                                                                                         |
+| [Intern.srib.no](/docs/produksjon/intern-srib-no)   | Dokumentdelingstjeneste brukt av produsentene. deres                                                                                                                                                          |
+| Database for digas                                  | Digas er radiospesifikk programvare. Vertet i VM med navn "Database"                                                                                                                                          |
 
 ## Oppsett
 

--- a/content/docs/kunder/studvest.md
+++ b/content/docs/kunder/studvest.md
@@ -1,8 +1,6 @@
 +++
 title = "Studvest"
 description = "Studvest"
-date = 2023-01-12T15:51:00+00:00
-updated = 2023-01-12T15:51:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -26,8 +24,8 @@ til Skrue.
 
 Sist Oppdatert: 12.01.2023
 
-| Domenenavn                                       | Kort forklaring                   |
-| ------------------------------------------------ | --------------------------------- |
+| Domenenavn                                               | Kort forklaring                   |
+| -------------------------------------------------------- | --------------------------------- |
 | [studvest.no](https://studvest.no)                       | Hovedside, ikke vertet av friByte |
 | [studvest-nc.fribyte.no](https://studvest-nc.fribyte.no) | Nextcloud server for Studvest     |
 

--- a/content/docs/maskiner/_index.md
+++ b/content/docs/maskiner/_index.md
@@ -1,12 +1,8 @@
 +++
 title = "Maskiner"
 description = "Oversikt over alle fysiske maskiner"
-date = 2022-03-17T16:19:00+00:00
-updated = 2022-03-17T16:19:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1
 draft = false
 +++
-
-

--- a/content/docs/maskiner/bolivar-skaftetrynet-pluto-cluster.md
+++ b/content/docs/maskiner/bolivar-skaftetrynet-pluto-cluster.md
@@ -1,8 +1,6 @@
 +++
 title = "Bolivar Skaftetrynet Pluto Proxmox Cluster"
 description = "Description of proxmox cluster setup on Bolivar Skaftetrynet and Pluto"
-date = 2023-05-02T16:19:00+00:00
-updated = 2023-05-02T16:19:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/maskiner/gjertrud.md
+++ b/content/docs/maskiner/gjertrud.md
@@ -1,25 +1,25 @@
 +++
 title = "Gjertrud"
 description = "Oversikt over Gjertrud"
-date = 2022-03-17T16:19:00+00:00
-updated = 2022-03-17T16:19:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1
 draft = false
 +++
 
-
 ## Gjertrud
 
 # Lagringsoppsett
 
-Gjertrud er i dag satt opp med alle diskene satt i sin egen Raid 1 gjennom det standard Raid kortet som sitter i hovedkortet på serveren. 
-Dette skal oppgraderes i fremtiden til et Dell H200 ( flashet til LSI 9211-8i IT-mode )
+Gjertrud er i dag satt opp med alle diskene satt i sin egen Raid 1 gjennom det
+standard Raid kortet som sitter i hovedkortet på serveren. Dette skal
+oppgraderes i fremtiden til et Dell H200 ( flashet til LSI 9211-8i IT-mode )
 
-Alle diskene i denne serveren kobles opp i et ZFS pool slik at vi kan bruke replication mellom Gjertrud og Konrad
+Alle diskene i denne serveren kobles opp i et ZFS pool slik at vi kan bruke
+replication mellom Gjertrud og Konrad
 
 # Ting lært
+
 For å kunne bruke et ekstrern HBA kort i denne serven:
 
 1. Disable det innebygde RAID kortet

--- a/content/docs/maskiner/konrad.md
+++ b/content/docs/maskiner/konrad.md
@@ -1,8 +1,6 @@
 +++
 title = "Konrad"
 description = "Oversikt over Konrad"
-date = 2022-03-17T16:19:00+00:00
-updated = 2022-09-22T16:19:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1
@@ -11,7 +9,9 @@ draft = false
 
 # Konrad
 
-**NB!** Konrad har problemer med å lagre BIOS konfigurasjon. Det er VELDIG VIKTIG at når Konrad rebootes så må man velge boot device. Gå inn i BIOS under boot, velg boot option med "Linux" i navnet. 
+**NB!** Konrad har problemer med å lagre BIOS konfigurasjon. Det er VELDIG
+VIKTIG at når Konrad rebootes så må man velge boot device. Gå inn i BIOS under
+boot, velg boot option med "Linux" i navnet.
 
 ## Proxmox
 
@@ -40,4 +40,3 @@ Vi satte opp serveren med lagring som beskrevet under
 [lagringsoppsett](#lagringsoppsett). Noen av diskene var satt opp i raid med
 lvm, disse ble wipet ved å bruke `lvremove` og `mdadm`. Vi prøvde tidligere et
 annet Alreca HBA kort, som ikke fungerte bra i denne serveren.
-

--- a/content/docs/maskiner/strom.md
+++ b/content/docs/maskiner/strom.md
@@ -1,8 +1,6 @@
 +++
 title = "Strøm"
 description = "Strøm oversikt"
-date = 2023-04-25T19:22:00+00:00
-updated = 2023-04-25T19:22:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/_index.md
+++ b/content/docs/nettverk/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Nettverk"
 description = "Oversikt over nettverket og nettverksrelaterte konfigurasjoner"
-date = 2022-01-18T08:00:00+00:00
-updated = 2022-01-18T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/brannmur.md
+++ b/content/docs/nettverk/brannmur.md
@@ -1,8 +1,6 @@
 +++
 title = "Redundant brannmur"
 description = "Informasjon om brannmuren til friByte"
-date = 2022-03-06T18:22:00+00:00
-updated = 2022-03-06T18:22:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/dns.md
+++ b/content/docs/nettverk/dns.md
@@ -1,8 +1,6 @@
 +++
 title = "DNS"
 description = "Informasjon om DNS-tjenesten til friByte"
-date = 2022-03-06T17:11:00+00:00
-updated = 2024-02-24T04:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/hardware-nettverk.md
+++ b/content/docs/nettverk/hardware-nettverk.md
@@ -1,8 +1,6 @@
 +++
 title = "Hardware nettverk"
 description = "En gjennomgang av pf-regelsettet som er i produksjon"
-date = 2013-06-05T18:53:00+00:00
-updated = 2021-02-26T18:53:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/nettverk-oversikt.md
+++ b/content/docs/nettverk/nettverk-oversikt.md
@@ -1,8 +1,6 @@
 +++
 title = "Nettverksoversikt"
 description = "Et forsøk på å få oversikt over maskiner på nettverket"
-date = 2022-03-17T04:22:00+00:00
-updated = 2022-03-28T04:22:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/regelsett-tutorial.md
+++ b/content/docs/nettverk/regelsett-tutorial.md
@@ -1,8 +1,6 @@
 +++
 title = "Fremgangsmåte for å skrive pf regelsett"
 description = "En forklaring på hvordan man skriver et regelsett i pf"
-date = 2022-03-06T18:52:00+00:00
-updated = 2022-03-06T18:52:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/nettverk/regelsett.md
+++ b/content/docs/nettverk/regelsett.md
@@ -1,8 +1,6 @@
 +++
 title = "Regelsett i produksjon"
 description = "En gjennomgang av pf-regelsettet som er i produksjon"
-date = 2022-03-06T18:53:00+00:00
-updated = 2022-03-06T18:53:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/produksjon/_index.md
+++ b/content/docs/produksjon/_index.md
@@ -1,11 +1,8 @@
 +++
 title = "I Produksjon"
 description = "En oversikt over alle tjenester i produksjon"
-date = 2023-12-19
-updated = 2023-12-19
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1
 draft = false
 +++
-

--- a/content/docs/produksjon/bilder-srib-no.md
+++ b/content/docs/produksjon/bilder-srib-no.md
@@ -1,23 +1,21 @@
 +++
 title = "bilder.srib.no"
 description = "Forklaring på hvordan bildelagringstjenesten til studentradioen er rigget opp"
-date = 2024-02-10T08:00:00+00:00
-updated = 2024-02-10T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
 draft = false
 +++
 
-
 ### Kort forklaring
 
-Dette er en tjeneste som studentradioen "bruker" for å lagre bildene sine. Det er en tjeneste som heter [PhotoPrism](https://github.com/photoprism/photoprism). 
+Dette er en tjeneste som studentradioen "bruker" for å lagre bildene sine. Det
+er en tjeneste som heter [PhotoPrism](https://github.com/photoprism/photoprism).
 
 ### Docker compose fil
 
 ```yaml
-version: '3.5'
+version: "3.5"
 
 # Example Docker Compose config file for PhotoPrism (Linux / AMD64)
 #
@@ -72,34 +70,34 @@ services:
     ports:
       - "2342:2342" # HTTP port (host:container)
     environment:
-      PHOTOPRISM_ADMIN_PASSWORD: "kekekek"  # YOUR INITIAL ADMIN PASSWORD (MINIMUM 8 CHARACTERS, USERNAME "admin")
-      PHOTOPRISM_SITE_URL: "https://bilder.srib.no/"  # public server URL incl http:// or https:// and /path, :port(2342) is optional
-      PHOTOPRISM_ORIGINALS_LIMIT: 50000               # file size limit for originals in MB (increase for high-res video)
-      PHOTOPRISM_HTTP_COMPRESSION: "gzip"            # improves transfer speed and bandwidth utilization (none or gzip)
-      PHOTOPRISM_LOG_LEVEL: "info"                   # log level: trace, debug, info, warning, error, fatal, or panic
-      PHOTOPRISM_PUBLIC: "false"                     # no authentication required (disables password protection)
-      PHOTOPRISM_READONLY: "false"                   # do not modify originals directory (reduced functionality)
-      PHOTOPRISM_EXPERIMENTAL: "false"               # enables experimental features
-      PHOTOPRISM_DISABLE_CHOWN: "false"              # disables storage permission updates on startup
-      PHOTOPRISM_DISABLE_WEBDAV: "false"             # disables built-in WebDAV server
-      PHOTOPRISM_DISABLE_SETTINGS: "false"           # disables settings UI and API
-      PHOTOPRISM_DISABLE_TENSORFLOW: "true"         # disables all features depending on TensorFlow
-      PHOTOPRISM_DISABLE_FACES: "true"              # disables facial recognition
-      PHOTOPRISM_DISABLE_CLASSIFICATION: "false"     # disables image classification
-      PHOTOPRISM_DISABLE_RAW: "false"                # disables indexing and conversion of RAW files
-      PHOTOPRISM_RAW_PRESETS: "false"                # enables applying user presets when converting RAW files (reduces performance)
-      PHOTOPRISM_JPEG_QUALITY: 85                    # image quality, a higher value reduces compression (25-100)
-      PHOTOPRISM_DETECT_NSFW: "false"                # flag photos as private that MAY be offensive (requires TensorFlow)
-      PHOTOPRISM_UPLOAD_NSFW: "true"                 # allows uploads that MAY be offensive
+      PHOTOPRISM_ADMIN_PASSWORD: "kekekek" # YOUR INITIAL ADMIN PASSWORD (MINIMUM 8 CHARACTERS, USERNAME "admin")
+      PHOTOPRISM_SITE_URL: "https://bilder.srib.no/" # public server URL incl http:// or https:// and /path, :port(2342) is optional
+      PHOTOPRISM_ORIGINALS_LIMIT: 50000 # file size limit for originals in MB (increase for high-res video)
+      PHOTOPRISM_HTTP_COMPRESSION: "gzip" # improves transfer speed and bandwidth utilization (none or gzip)
+      PHOTOPRISM_LOG_LEVEL: "info" # log level: trace, debug, info, warning, error, fatal, or panic
+      PHOTOPRISM_PUBLIC: "false" # no authentication required (disables password protection)
+      PHOTOPRISM_READONLY: "false" # do not modify originals directory (reduced functionality)
+      PHOTOPRISM_EXPERIMENTAL: "false" # enables experimental features
+      PHOTOPRISM_DISABLE_CHOWN: "false" # disables storage permission updates on startup
+      PHOTOPRISM_DISABLE_WEBDAV: "false" # disables built-in WebDAV server
+      PHOTOPRISM_DISABLE_SETTINGS: "false" # disables settings UI and API
+      PHOTOPRISM_DISABLE_TENSORFLOW: "true" # disables all features depending on TensorFlow
+      PHOTOPRISM_DISABLE_FACES: "true" # disables facial recognition
+      PHOTOPRISM_DISABLE_CLASSIFICATION: "false" # disables image classification
+      PHOTOPRISM_DISABLE_RAW: "false" # disables indexing and conversion of RAW files
+      PHOTOPRISM_RAW_PRESETS: "false" # enables applying user presets when converting RAW files (reduces performance)
+      PHOTOPRISM_JPEG_QUALITY: 85 # image quality, a higher value reduces compression (25-100)
+      PHOTOPRISM_DETECT_NSFW: "false" # flag photos as private that MAY be offensive (requires TensorFlow)
+      PHOTOPRISM_UPLOAD_NSFW: "true" # allows uploads that MAY be offensive
       # PHOTOPRISM_DATABASE_DRIVER: "sqlite"         # SQLite is an embedded database that doesn't require a server
-      PHOTOPRISM_DATABASE_DRIVER: "mysql"            # use MariaDB 10.5+ or MySQL 8+ instead of SQLite for improved performance
-      PHOTOPRISM_DATABASE_SERVER: "mariadb:3306"     # MariaDB or MySQL database server (hostname:port)
-      PHOTOPRISM_DATABASE_NAME: "photoprism_db"         # MariaDB or MySQL database schema name
-      PHOTOPRISM_DATABASE_USER: "photoprism"         # MariaDB or MySQL database user name
-      PHOTOPRISM_DATABASE_PASSWORD: "lololol"       # MariaDB or MySQL database user password
+      PHOTOPRISM_DATABASE_DRIVER: "mysql" # use MariaDB 10.5+ or MySQL 8+ instead of SQLite for improved performance
+      PHOTOPRISM_DATABASE_SERVER: "mariadb:3306" # MariaDB or MySQL database server (hostname:port)
+      PHOTOPRISM_DATABASE_NAME: "photoprism_db" # MariaDB or MySQL database schema name
+      PHOTOPRISM_DATABASE_USER: "photoprism" # MariaDB or MySQL database user name
+      PHOTOPRISM_DATABASE_PASSWORD: "lololol" # MariaDB or MySQL database user password
       PHOTOPRISM_SITE_CAPTION: "Studentradioen i Bergen"
-      PHOTOPRISM_SITE_DESCRIPTION: "Bildene til SRiB"    # meta site description
-      PHOTOPRISM_SITE_AUTHOR: "SRiB"                         # meta site author
+      PHOTOPRISM_SITE_DESCRIPTION: "Bildene til SRiB" # meta site description
+      PHOTOPRISM_SITE_AUTHOR: "SRiB" # meta site author
       #PHOTOPRISM_DEBUG: "true"
       ## Run/install on first startup (options: update, gpu, tensorflow, davfs, clitools, clean):
       # PHOTOPRISM_INIT: "gpu tensorflow"
@@ -129,10 +127,10 @@ services:
     ## Storage Folders: "~" is a shortcut for your home directory, "." for the current directory
     volumes:
       # "/host/folder:/photoprism/folder"                # Example
-      - "/home/fribyte/photoprism/srib-bilder:/photoprism/originals"               # Original media files (DO NOT REMOVE
+      - "/home/fribyte/photoprism/srib-bilder:/photoprism/originals" # Original media files (DO NOT REMOVE
       # - "/example/family:/photoprism/originals/family" # *Additional* media folders can be mounted like this
       # - "~/Import:/photoprism/import"                  # *Optional* base folder from which files can be imported to originals
-      - "./storage:/photoprism/storage"                  # *Writable* storage folder for cache, database, and sidecar files (DO NOT REMOVE) 
+      - "./storage:/photoprism/storage" # *Writable* storage folder for cache, database, and sidecar files (DO NOT REMOVE)
       - "/home/fribyte/photoprism/srib-bilder"
     networks:
       - frontend
@@ -147,7 +145,11 @@ services:
     security_opt:
       - seccomp:unconfined
       - apparmor:unconfined
-    command: mysqld --innodb-buffer-pool-size=128M --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --max-connections=512 --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
+    command:
+      mysqld --innodb-buffer-pool-size=128M
+      --transaction-isolation=READ-COMMITTED --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci --max-connections=512
+      --innodb-rollback-on-timeout=OFF --innodb-lock-wait-timeout=120
     ## Never store database files on an unreliable device such as a USB flash drive, an SD card, or a shared network folder:
     volumes:
       - "./database:/var/lib/mysql" # DO NOT REMOVE
@@ -175,37 +177,47 @@ services:
   #     - "~/.docker/config.json:/config.json" # optional, for authentication if you have a Docker Hub account
   #
 networks:
- frontend:
-  external: true
+  frontend:
+    external: true
 ```
 
 Det som er greit å bemerke seg her, er dette:
 
 ```yaml
-    volumes:
-      (...)
+volumes: (...)
 
-      - "/home/fribyte/photoprism/srib-bilder:/photoprism/originals"
-      
-      (...)
+  - "/home/fribyte/photoprism/srib-bilder:/photoprism/originals"
 
-      - "/home/fribyte/photoprism/srib-bilder"
+  (...)
+
+  - "/home/fribyte/photoprism/srib-bilder"
 ```
 
-Vi importerer en lokal mappe på VM-en inn i Docker-beholderen. Dette er samme praksis som [podcast.srib.no](/docs/produksjon/podcast-srib-no)
+Vi importerer en lokal mappe på VM-en inn i Docker-beholderen. Dette er samme
+praksis som [podcast.srib.no](/docs/produksjon/podcast-srib-no)
 
-Den lokale mappen er også en importert mappe fra NAS-et til Studentradioen. Vi bruker den følgende linjen i fstab for å importere mappen fra NAS-et. 
+Den lokale mappen er også en importert mappe fra NAS-et til Studentradioen. Vi
+bruker den følgende linjen i fstab for å importere mappen fra NAS-et.
 
 ```
 //158.37.6.118/Bilder/  /home/fribyte/photoprism/srib-bilder    cifs    vers=3.0,username=fribyte,password=aiaiaiai,noexec  0 0
 ```
-Brukernavn og passord, er til brukeren i NAS-et til studentradioen. Fildelingen krever at studentradioen godkjenner at vi kan koble oss til NAS-et deres, gjennom programvaren til NAS-et deres. Passordet kan du finne i [bitwarden.fribyte.no](https://bitwarden.fribyte.no)
 
-Dette er for både lesing og skriving, selvfølgelig. Filer som ligger i den mappen på NAS-et blir vist i `bilder.srib.no`, og alle bilder som blir lastet opp til `bilder.srib.no`, ender opp på NAS-et deres.
+Brukernavn og passord, er til brukeren i NAS-et til studentradioen. Fildelingen
+krever at studentradioen godkjenner at vi kan koble oss til NAS-et deres,
+gjennom programvaren til NAS-et deres. Passordet kan du finne i
+[bitwarden.fribyte.no](https://bitwarden.fribyte.no)
 
-NAS-et deres er av typen QNAP TS-853BU, [og du kan lese mer om det her](https://wiki.srib.no/docs/machines/servers/mimir/).
+Dette er for både lesing og skriving, selvfølgelig. Filer som ligger i den
+mappen på NAS-et blir vist i `bilder.srib.no`, og alle bilder som blir lastet
+opp til `bilder.srib.no`, ender opp på NAS-et deres.
 
+NAS-et deres er av typen QNAP TS-853BU,
+[og du kan lese mer om det her](https://wiki.srib.no/docs/machines/servers/mimir/).
 
 ### client_max_body_size problemer
 
-I utgangspunktet var det et problem med at størrelsen på bildet som ble forsøkt lastet opp var for stort. Dette var fordi `client_max_body_size` i nginx-proxy sin nginx.conf var satt 1MB, mens Azuracast sin `client_max_body_size` var satt til 50MB. Så da satte vi nginx-proxy sin `client_max_body_size` til 50MB også. 
+I utgangspunktet var det et problem med at størrelsen på bildet som ble forsøkt
+lastet opp var for stort. Dette var fordi `client_max_body_size` i nginx-proxy
+sin nginx.conf var satt 1MB, mens Azuracast sin `client_max_body_size` var satt
+til 50MB. Så da satte vi nginx-proxy sin `client_max_body_size` til 50MB også.

--- a/content/docs/produksjon/booking-srib-no.md
+++ b/content/docs/produksjon/booking-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "booking.srib.no"
 description = "Forklaring på hvordan romreservasjonssystemet til radioen er skrudd sammen"
-date = 2024-01-23T08:00:00+00:00
-updated = 2024-01-23T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,9 +9,12 @@ draft = false
 
 ### Kort forklaring
 
-Romreservasjonstjenesten vi leverer for radioen er en av de viktigste. Uten den, blir det ikke mulig for dem å vite hvem av de 200 aktive medlemmene deres som låner lokalene til hvilke tider.
+Romreservasjonstjenesten vi leverer for radioen er en av de viktigste. Uten den,
+blir det ikke mulig for dem å vite hvem av de 200 aktive medlemmene deres som
+låner lokalene til hvilke tider.
 
-Programvaren er [Meeting Room Booking System](https://mrbs.sourceforge.io/), og kjører vanligvis i en LAMP stack. I vårt tilfelle kjører vi den gjennom Docker.
+Programvaren er [Meeting Room Booking System](https://mrbs.sourceforge.io/), og
+kjører vanligvis i en LAMP stack. I vårt tilfelle kjører vi den gjennom Docker.
 
 ### Docker compose fil
 
@@ -58,11 +59,12 @@ services:
     networks:
       - frontend
 networks:
- frontend:
-  external: true
+  frontend:
+    external: true
 ```
 
-Det er ikke noe spesielt triks med denne compose-filen, men det er greit å merke seg volumene som importeres: 
+Det er ikke noe spesielt triks med denne compose-filen, men det er greit å merke
+seg volumene som importeres:
 
 ```yaml
 volumes:
@@ -74,8 +76,12 @@ volumes:
   - ./config/mysql:/var/lib/mysql
 ```
 
-Altså, at `config`-mappen inneholder alle filene som database-beholderen og mrbs-beholderen bruker.
+Altså, at `config`-mappen inneholder alle filene som database-beholderen og
+mrbs-beholderen bruker.
 
 ### Endre variabler i mrbs
 
-Om du ønsker å endre variabler i mrbs-tjenesten, for diverse grunner, kan du gjøre det ved å manuelt endre php-koden. Da kan du bare åpne `./config/mrbs/www/config.inc.php` med et tekstredigeringsprogram. Endringene burde skje ganske umiddelbart.
+Om du ønsker å endre variabler i mrbs-tjenesten, for diverse grunner, kan du
+gjøre det ved å manuelt endre php-koden. Da kan du bare åpne
+`./config/mrbs/www/config.inc.php` med et tekstredigeringsprogram. Endringene
+burde skje ganske umiddelbart.

--- a/content/docs/produksjon/lytt-srib-no.md
+++ b/content/docs/produksjon/lytt-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "lytt.srib.no"
 description = "Forklaring på hvordan den statiske nettsiden som serverer nettradioen"
-date = 2022-02-25T08:00:00+00:00
-updated = 2024-01-11T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,7 +9,11 @@ draft = false
 
 ### Statisk side i Docker
 
-For å hoste en statisk side må du servere filene gjennom en http-server som nginx. For eksempel [lytt.srib.no](https://lytt.srib.no) blir hostet ved at en statisk `index.html` ligger i mappen `/var/www/html/srib.no/lytt`. Vi kjører en nginx container som kun serverer filer fra denne mappen ved å mounte mappen med følgende kommando:
+For å hoste en statisk side må du servere filene gjennom en http-server som
+nginx. For eksempel [lytt.srib.no](https://lytt.srib.no) blir hostet ved at en
+statisk `index.html` ligger i mappen `/var/www/html/srib.no/lytt`. Vi kjører en
+nginx container som kun serverer filer fra denne mappen ved å mounte mappen med
+følgende kommando:
 
 ```sh
 sudo docker run -d --restart always \
@@ -25,12 +27,19 @@ nginx:latest
 
 ### HTML iframe-tag
 
-Azuracast genererer en `iframe`-tag for de offentlige "mountpoints"-ene til IceCast2-maskineriet. En "mountpoint" er på en måte en krok du kan henge lydstrømmer på; en mottaker for lydstrømmen din, som videresender den ut på nettet gjennom sitt eget domene. 
+Azuracast genererer en `iframe`-tag for de offentlige "mountpoints"-ene til
+IceCast2-maskineriet. En "mountpoint" er på en måte en krok du kan henge
+lydstrømmer på; en mottaker for lydstrømmen din, som videresender den ut på
+nettet gjennom sitt eget domene.
 
 For radioen sitt tilfelle, ser den slik ut:
 
 ```html
-<iframe src="https://radio.srib.no/public/studentradioen_i_bergen/embed?theme=light" frameborder="0" allowtransparency="true" style="width: 100%; min-height: 150px; border: 0;"></iframe>
+<iframe
+  src="https://radio.srib.no/public/studentradioen_i_bergen/embed?theme=light"
+  frameborder="0"
+  allowtransparency="true"
+  style="width: 100%; min-height: 150px; border: 0;"></iframe>
 ```
 
 Dette er limt rett inn i `index.html`, som nevnt tidligere.

--- a/content/docs/produksjon/podcast-srib-no.md
+++ b/content/docs/produksjon/podcast-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "podcast.srib.no"
 description = "Forklaring på hvordan podcast-tjenesten til studentradioen er rigget opp"
-date = 2024-01-23T08:00:00+00:00
-updated = 2024-02-10T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5

--- a/content/docs/produksjon/radio-srib-no.md
+++ b/content/docs/produksjon/radio-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "radio.srib.no"
 description = "Oversikt over AzuraCast og IceCast2 som tilrettelegger for srib sin nettradio."
-date = 2022-02-25T08:00:00+00:00
-updated = 2024-01-11T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,22 +9,42 @@ draft = false
 
 ### SRIB - AzuraCast & Icecast server
 
-[AzuraCast](https://docs.azuracast.com/en/home) er et gratis åpen kildekode program for å drifte nettradio og annet. Den kommer innebygget med [Icecast server](https://icecast.org/) som brukes for å strømme lyd fra en eller flere kilder til mange klienter. For eksempel tusenvis av nettsidebesøkere. Dette brukes for å lage drifte [lytt.srib.no](lytt.srib.no) til SRIB i dag.
+[AzuraCast](https://docs.azuracast.com/en/home) er et gratis åpen kildekode
+program for å drifte nettradio og annet. Den kommer innebygget med
+[Icecast server](https://icecast.org/) som brukes for å strømme lyd fra en eller
+flere kilder til mange klienter. For eksempel tusenvis av nettsidebesøkere.
+Dette brukes for å lage drifte [lytt.srib.no](lytt.srib.no) til SRIB i dag.
 
 ### Hosting
 
-AzuraCast-tjenesten vertes på VM-en `srib-radio` i [ProxMox-clusteret](/docs/maskiner/bolivar-skaftetrynet-pluto-cluster) som en docker compose-instans. 
+AzuraCast-tjenesten vertes på VM-en `srib-radio` i
+[ProxMox-clusteret](/docs/maskiner/bolivar-skaftetrynet-pluto-cluster) som en
+docker compose-instans.
 
-AzuraCast har en helt utrolig bra installer som er brukt til å sette opp systemet. [AzuraCast Docker installation guide](https://docs.azuracast.com/en/administration/docker/multi-site-installation). Filene ligger i mappen `/var/azuracast`. 
+AzuraCast har en helt utrolig bra installer som er brukt til å sette opp
+systemet.
+[AzuraCast Docker installation guide](https://docs.azuracast.com/en/administration/docker/multi-site-installation).
+Filene ligger i mappen `/var/azuracast`.
 
-For å støtte å hoste flere docker containere på samme VM har vi brukt stegene under `AzuraCast Multi-Site Feature` som setter opp nginx-reverse-proxy og automatisk SSL sertifisering. 
+For å støtte å hoste flere docker containere på samme VM har vi brukt stegene
+under `AzuraCast Multi-Site Feature` som setter opp nginx-reverse-proxy og
+automatisk SSL sertifisering.
 
-Husk at andre docker containere må kobles til nettverket: `azuracast_frontend` for å at reverse proxy skal kunne se containerene.
+Husk at andre docker containere må kobles til nettverket: `azuracast_frontend`
+for å at reverse proxy skal kunne se containerene.
 
 ### Funksjoner
 
-AzuraCast har mange fancy funksjoner, disse kan utforskes på domenet til srib-radio vm'en. Av ting vi kanskje kan se på er å mounte srib-nasen til AzuraCast og sette opp automatisk avspilling av mediafiler når man ikke får inn noe signal på icecast-tjeneren. Dette kan potensielt fjerne behovet for den dedikerte maskinen i SRIB sitt server-rom.
+AzuraCast har mange fancy funksjoner, disse kan utforskes på domenet til
+srib-radio vm'en. Av ting vi kanskje kan se på er å mounte srib-nasen til
+AzuraCast og sette opp automatisk avspilling av mediafiler når man ikke får inn
+noe signal på icecast-tjeneren. Dette kan potensielt fjerne behovet for den
+dedikerte maskinen i SRIB sitt server-rom.
 
 AzuraCast har også en podcast funksjon som kan være verdt å se på.
 
-Det er og en [streamers & DJs](https://docs.azuracast.com/en/user-guide/streamers-and-djs) funksjon som ikke virker akkurat nå pga noe port trøbbel. Men som åpner for at flere kilder kan strømme inn lyd og så kan make trikse og mikse mellom strømmerne. Potensielt noe som kan brukes på utesendinger.
+Det er og en
+[streamers & DJs](https://docs.azuracast.com/en/user-guide/streamers-and-djs)
+funksjon som ikke virker akkurat nå pga noe port trøbbel. Men som åpner for at
+flere kilder kan strømme inn lyd og så kan make trikse og mikse mellom
+strømmerne. Potensielt noe som kan brukes på utesendinger.

--- a/content/docs/produksjon/skjema-srib-no.md
+++ b/content/docs/produksjon/skjema-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "skjema.srib.no"
 description = "Forklaring på hvordan hvordan spørreskjema-siden til radioen er skrudd sammen"
-date = 2024-02-10T08:00:00+00:00
-updated = 2024-02-10T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,50 +9,51 @@ draft = false
 
 ### Kort forklaring
 
-Studentradioen bruker denne tjenesten for å opprette spørreskjemaer. Det er en programvare som heter [LimeSurvey](https://github.com/LimeSurvey/LimeSurvey). 
+Studentradioen bruker denne tjenesten for å opprette spørreskjemaer. Det er en
+programvare som heter [LimeSurvey](https://github.com/LimeSurvey/LimeSurvey).
 
 ### Docker compose fil
 
 ```yaml
-version: '3'
+version: "3"
 
 services:
-    limesurvey:
-      image: docker.io/martialblog/limesurvey:latest
-      restart: always
-      networks:
-        - frontend
-      environment:
-        - DB_TYPE=pgsql
-        - DB_PORT=5432
-        - DB_HOST=limesurvey-db
-        - DB_PASSWORD=lololol
-        - DB_NAME=limesurvey
-        - DB_USERNAME=limesurvey
-        - ADMIN_USER=admin
-        - ADMIN_NAME=friByte
-        - ADMIN_PASSWORD=kekekek
-        - ADMIN_EMAIL=admin@fribyte.no
-        - VIRTUAL_HOST=skjema.srib.no
-        - LETSENCRYPT_HOST=skjema.srib.no
-        - PUBLIC_URL=skjema.srib.no
-        - VIRTUAL_PORT=8080
-      volumes:
-        - limesurvey:/var/www/html/upload/surveys
-      depends_on:
-        - limesurvey-db
+  limesurvey:
+    image: docker.io/martialblog/limesurvey:latest
+    restart: always
+    networks:
+      - frontend
+    environment:
+      - DB_TYPE=pgsql
+      - DB_PORT=5432
+      - DB_HOST=limesurvey-db
+      - DB_PASSWORD=lololol
+      - DB_NAME=limesurvey
+      - DB_USERNAME=limesurvey
+      - ADMIN_USER=admin
+      - ADMIN_NAME=friByte
+      - ADMIN_PASSWORD=kekekek
+      - ADMIN_EMAIL=admin@fribyte.no
+      - VIRTUAL_HOST=skjema.srib.no
+      - LETSENCRYPT_HOST=skjema.srib.no
+      - PUBLIC_URL=skjema.srib.no
+      - VIRTUAL_PORT=8080
+    volumes:
+      - limesurvey:/var/www/html/upload/surveys
+    depends_on:
+      - limesurvey-db
 
-    limesurvey-db:
-      image: docker.io/postgres:10-alpine
-      restart: always
-      volumes:
-        - limesurvey-db-data:/var/lib/postgresql
-      environment:
-        - POSTGRES_USER=limesurvey
-        - POSTGRES_DB=limesurvey
-        - POSTGRES_PASSWORD=lolololol
-      networks:
-        - frontend
+  limesurvey-db:
+    image: docker.io/postgres:10-alpine
+    restart: always
+    volumes:
+      - limesurvey-db-data:/var/lib/postgresql
+    environment:
+      - POSTGRES_USER=limesurvey
+      - POSTGRES_DB=limesurvey
+      - POSTGRES_PASSWORD=lolololol
+    networks:
+      - frontend
 
 networks:
   frontend:
@@ -64,4 +63,3 @@ volumes:
   limesurvey:
   limesurvey-db-data:
 ```
-

--- a/content/docs/produksjon/srib-minecraft.md
+++ b/content/docs/produksjon/srib-minecraft.md
@@ -1,8 +1,6 @@
 +++
 title = "SRiB Minecraft server"
 description = "Alt du trenger å vite om minecraft-serveren til SRiB"
-date = 2022-12-30T04:00:00+00:00
-updated = 2024-02-10
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1
@@ -11,14 +9,15 @@ draft = false
 
 # SRiB Minecraft Server
 
-Dette er et dokument som beskriver alt du trenger å vite om SRiB sin ;MineCraft server
+Dette er et dokument som beskriver alt du trenger å vite om SRiB sin ;MineCraft
+server
 
 ## Installasjon
 
 ### Miljø
 
-Operativsystemet er en fersk installasjon av Ubuntu 22.04 på en virtuell
-maskin i ProxMox 8 Utenom det er det ingen spesielle miljø-konfigurasjoner.
+Operativsystemet er en fersk installasjon av Ubuntu 22.04 på en virtuell maskin
+i ProxMox 8 Utenom det er det ingen spesielle miljø-konfigurasjoner.
 
 ### Prosessen
 

--- a/content/docs/produksjon/srib-no.md
+++ b/content/docs/produksjon/srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "srib.no"
 description = "Studentradioen sin Wordpress hjemmeside"
-date = 2024-01-11T14:00:00+00:00
-updated = 2024-01-11T14:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,11 +9,16 @@ draft = false
 
 ## Kort forklaring
 
-[Studentradioen i Bergen](/docs/kunder/studentradioen) sin hjemmeside er en Wordpress-installasjon som kjører i et Docker-miljø. Docker-miljøet kjører på en virtuell maskin, som heter "Pengebingen", i [Proxmox-miljøet](/docs/maskiner/bolivar-skaftetrynet-pluto-cluster) vårt. 
+[Studentradioen i Bergen](/docs/kunder/studentradioen) sin hjemmeside er en
+Wordpress-installasjon som kjører i et Docker-miljø. Docker-miljøet kjører på en
+virtuell maskin, som heter "Pengebingen", i
+[Proxmox-miljøet](/docs/maskiner/bolivar-skaftetrynet-pluto-cluster) vårt.
 
 ## Docker compose fil
 
-For å lansere nettsiden bruker vi docker compose. Det tillater oss å lagre konfigurasjonen mer sikkert over lengre tid, samt feilsøke og lansere mye enklere. 
+For å lansere nettsiden bruker vi docker compose. Det tillater oss å lagre
+konfigurasjonen mer sikkert over lengre tid, samt feilsøke og lansere mye
+enklere.
 
 ```yaml
 version: "3.0"
@@ -24,10 +27,10 @@ services:
     image: webdevops/php-apache:7.4-alpine
     container_name: srib-wp
     volumes:
-    - /home/fribyte/srib.no/srib.no/hovedside/:/app/
-    - wp_uploads:/app/hovedside/wp-content/uploads
+      - /home/fribyte/srib.no/srib.no/hovedside/:/app/
+      - wp_uploads:/app/hovedside/wp-content/uploads
     expose:
-    - 80
+      - 80
     restart: always
     environment:
       VIRTUAL_PORT: 80
@@ -51,15 +54,15 @@ services:
     cap_add:
       - SYS_NICE
     environment:
-      MYSQL_DATABASE: 'lolololol'
-      MYSQL_USER: 'lolololol'
-      MYSQL_PASSWORD: 'lolol'
-      MYSQL_ROOT_PASSWORD: 'lolol'
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'false'
+      MYSQL_DATABASE: "lolololol"
+      MYSQL_USER: "lolololol"
+      MYSQL_PASSWORD: "lolol"
+      MYSQL_ROOT_PASSWORD: "lolol"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "false"
     ports:
-      - '3306:3306'
+      - "3306:3306"
     expose:
-      - '3306'
+      - "3306"
     volumes:
       - wp_mysql:/var/lib/mysql
     networks:
@@ -79,7 +82,11 @@ networks:
     external: true
 ```
 
-NB: Det er viktig å bemerke seg `image: webdevops/php-apache:7.4-alpine`. Det er dette som bestemmer php-versjonen som wordpress-installasjonen skal bruke. Temaet som nettsiden bruker, er ganske avhengig av at riktig php-versjon. Hvis ikke, kræsjer hele nettsiden. Om denne versjonen, 7.4, blir for utdatert for Wordpress-utvidelsene, må versjonen oppdateres. 
+NB: Det er viktig å bemerke seg `image: webdevops/php-apache:7.4-alpine`. Det er
+dette som bestemmer php-versjonen som wordpress-installasjonen skal bruke.
+Temaet som nettsiden bruker, er ganske avhengig av at riktig php-versjon. Hvis
+ikke, kræsjer hele nettsiden. Om denne versjonen, 7.4, blir for utdatert for
+Wordpress-utvidelsene, må versjonen oppdateres.
 
 ## Filopplasting og fillagring
 
@@ -96,13 +103,21 @@ volumes:
       allow_other: ""
 ```
 
-Er det som tillater lagring av opplastede media på [fillagringsmaskinen, Skrue](/docs/maskiner/skrue). Det er nå kofigurert slik at når en laster opp filer til Wordpress-siden, gjennom brukergrensesnittet, lagres filene på Skrue, i den designerte mappen i `sshcmd`. 
+Er det som tillater lagring av opplastede media på
+[fillagringsmaskinen, Skrue](/docs/maskiner/skrue). Det er nå kofigurert slik at
+når en laster opp filer til Wordpress-siden, gjennom brukergrensesnittet, lagres
+filene på Skrue, i den designerte mappen i `sshcmd`.
 
-For å kunne gjøre dette, må du installere Docker-utvidelsen `vieux/sshfs:latest`. Det gjør du slik: `docker plugin install vieux/sshfs`. `password` blir da passordet til brukeren du logger på maskinen som. I dette tilfellet er `lolololol` passordet til `root`.
+For å kunne gjøre dette, må du installere Docker-utvidelsen
+`vieux/sshfs:latest`. Det gjør du slik: `docker plugin install vieux/sshfs`.
+`password` blir da passordet til brukeren du logger på maskinen som. I dette
+tilfellet er `lolololol` passordet til `root`.
 
 ## Database-lagring
 
-Wordpress-installasjonen trenger naturligvis en database. Det vi bruker som database er en mysql-server på en egen [database-VM](/docs/instrukser/migrere-database).
+Wordpress-installasjonen trenger naturligvis en database. Det vi bruker som
+database er en mysql-server på en egen
+[database-VM](/docs/instrukser/migrere-database).
 
 Den er koblet opp ved å spesifisere følgende i `wp-config.php`:
 
@@ -124,6 +139,7 @@ define('DB_HOST', '158.37.6.37');
 #.........
 ```
 
-NB: `db_name`, `db_user` og `lolololol` er bare selvfølgelig plassholdere. 
+NB: `db_name`, `db_user` og `lolololol` er bare selvfølgelig plassholdere.
 
-For at denne tilkoblingen skal fungere, må du åpne for tilkobling i mysql-tjeneren, samt gi de riktige rettighetene i sql-databasen til `db_user`.
+For at denne tilkoblingen skal fungere, må du åpne for tilkobling i
+mysql-tjeneren, samt gi de riktige rettighetene i sql-databasen til `db_user`.

--- a/content/docs/produksjon/wiki-srib-no.md
+++ b/content/docs/produksjon/wiki-srib-no.md
@@ -1,8 +1,6 @@
 +++
 title = "wiki.srib.no"
 description = "Forklaring på hvordan wiki-siden er skrudd sammen"
-date = 2024-01-25T08:00:00+00:00
-updated = 2024-01-25T08:00:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 5
@@ -11,7 +9,10 @@ draft = false
 
 ### Kort forklaring
 
-Wiki-siden til radioen er statisk nettside, laget med [Docsy-temaet til Hugo](https://github.com/google/docsy). Du kan finne [repoet til koden her](https://github.com/srib-dev/wiki). Repoet er egentlig bare klonet fra det originale repoet og kjører i en docker-beholder.
+Wiki-siden til radioen er statisk nettside, laget med
+[Docsy-temaet til Hugo](https://github.com/google/docsy). Du kan finne
+[repoet til koden her](https://github.com/srib-dev/wiki). Repoet er egentlig
+bare klonet fra det originale repoet og kjører i en docker-beholder.
 
 ### Docker compose fil
 
@@ -37,6 +38,6 @@ services:
       - frontend
 
 networks:
- frontend:
-  external: true
+  frontend:
+    external: true
 ```

--- a/content/docs/proxmox_setups/HA-setup.md
+++ b/content/docs/proxmox_setups/HA-setup.md
@@ -1,8 +1,6 @@
 +++
 title = "High availability configuration"
 description = "Simple walkthough of our current HA setup"
-date = 2022-03-06T18:53:00+00:00
-updated = 2022-03-06T18:53:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/proxmox_setups/Load-balancers.md
+++ b/content/docs/proxmox_setups/Load-balancers.md
@@ -1,8 +1,6 @@
 +++
 title = "Load-balancers"
 description = "Simple walkthough of our current HA setup"
-date = 2022-03-06T18:53:00+00:00
-updated = 2022-03-06T18:53:00+00:00
 template = "docs/page.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/proxmox_setups/_index.md
+++ b/content/docs/proxmox_setups/_index.md
@@ -1,11 +1,7 @@
 +++
 title = "Proxmox"
 description = "Description of setups within Proxmox"
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 template = "docs/section.html"
 +++
-
-

--- a/content/docs/spill/_index.md
+++ b/content/docs/spill/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Spill"
 description = "Spill driftet av oss"
-date = 2022-12-30T03:58:00+00:00
-updated = 2022-12-30T03:58:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/tjenester/_index.md
+++ b/content/docs/tjenester/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Tjenester"
 description = "Oversikt over tjenester vi drifter for oss selv og klienter"
-date = 2022-03-17T15:56:00+00:00
-updated = 2022-03-17T15:56:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/content/docs/tjenester/guffen.md
+++ b/content/docs/tjenester/guffen.md
@@ -1,8 +1,6 @@
 +++
 title = "Github runner"
 description = "Guffen self-hosted github actions runner"
-date = 2024-05-07
-updated = 2024-05-07
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3
@@ -11,12 +9,17 @@ weight = 3
 Guffen er en VM på gjertrud satt opp til å kjøre github actions tasks.
 
 ## Oppsett
-Runneren er satt opp på [metoden oppgitt av GitHub](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository)
+
+Runneren er satt opp på
+[metoden oppgitt av GitHub](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners#adding-a-self-hosted-runner-to-a-repository)
 
 Startskriptet for programmet ligger i `/home/fribyte/actions-runner/run.sh`
 
 ### Systemd service
-For at programmet skal kjøre i bakgrunnen og starte av seg selv er det opprettet en systemd service som ligger i `/home/fribyte/.config/systemd/user/actions-runner.service`:
+
+For at programmet skal kjøre i bakgrunnen og starte av seg selv er det opprettet
+en systemd service som ligger i
+`/home/fribyte/.config/systemd/user/actions-runner.service`:
 
 ```
 [Unit]
@@ -32,15 +35,19 @@ Restart=always
 WantedBy=default.target
 ```
 
-Følgende kommando kan brukes for *enable/start/stop* av servicen:
+Følgende kommando kan brukes for _enable/start/stop_ av servicen:
+
 ```bash
 systemctl --user enable actions-runner.service
 ```
 
 ## Bruk
-For at runneren skal brukes for å kjøre actions må man sette *runs-on* til self-hosted i actions filen.
 
- f.eks:
+For at runneren skal brukes for å kjøre actions må man sette _runs-on_ til
+self-hosted i actions filen.
+
+f.eks:
+
 ```yaml
 jobs:
   push_to_registry:
@@ -48,13 +55,21 @@ jobs:
     runs-on: self-hosted
 ```
 
-Hvis actions scriptet inneholder et docker build step kreves ogsa følgende som et step før byggingen i filen.
+Hvis actions scriptet inneholder et docker build step kreves ogsa følgende som
+et step før byggingen i filen.
+
 ```yaml
         - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 ```
 
 ## Sikkerhet
-Med bruken av en self hosted runner inngår det også visse regler man burde opprettholde for å unngå brudd på sikkerheten. Dette er fordi runneren kjører arbitrær kode som i teorien kan unnslippe sandbox miljøet. For å unngå slike situasjoner anbefales det å kun tillate actions scripts i offentlige repositories å kjøre på en godkjent merge med main branch.
 
-For fremtidig referanse se [GitHub runner sikkerhets dokumentasjon](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security).
+Med bruken av en self hosted runner inngår det også visse regler man burde
+opprettholde for å unngå brudd på sikkerheten. Dette er fordi runneren kjører
+arbitrær kode som i teorien kan unnslippe sandbox miljøet. For å unngå slike
+situasjoner anbefales det å kun tillate actions scripts i offentlige
+repositories å kjøre på en godkjent merge med main branch.
+
+For fremtidig referanse se
+[GitHub runner sikkerhets dokumentasjon](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security).

--- a/content/docs/tjenester/mattermost.md
+++ b/content/docs/tjenester/mattermost.md
@@ -1,8 +1,6 @@
 +++
 title = "Mattermost"
 description = "Intern kommunikasjon"
-date = 2022-03-12
-updated = 2022-03-12
 template = "docs/page.html"
 sort_by = "weight"
 weight = 3
@@ -103,7 +101,8 @@ sudo docker-compose -f ./docker/docker-compose.yml -f ./docker/docker-compose.ng
 
 ### Lage nye sertifikat configs
 
-Skulle stegene over ikke fungere er det også mulig å lage nye sertifikat konfigurasjonsfiler med følgende kommando
+Skulle stegene over ikke fungere er det også mulig å lage nye sertifikat
+konfigurasjonsfiler med følgende kommando
 
 _For fremtidige generasjoner: for å kunne issue et nytt sertifikat kreves det at
 nginx_mattermost containeren er stoppet, dette er fordi certbot container

--- a/content/privacy-policy/_index.md
+++ b/content/privacy-policy/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Privacy Policy"
 description = "We do not use cookies and we do not collect any personal data."
-date = 2021-05-01T08:00:00+00:00
-updated = 2020-05-01T08:00:00+00:00
 draft = false
 
 [extra]

--- a/themes/adidoks/content/authors/_index.md
+++ b/themes/adidoks/content/authors/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Authors"
 description = "The authurs of the blog articles."
-date = 2021-04-01T08:00:00+00:00
-updated = 2021-04-01T08:00:00+00:00
 draft = false
 
 # If add a new author page in this section, please add a new item,

--- a/themes/adidoks/content/authors/aaran-xu.md
+++ b/themes/adidoks/content/authors/aaran-xu.md
@@ -1,8 +1,6 @@
 +++
 title = "Aaran Xu"
 description = "Creator of AdiDoks."
-date = 2021-04-01T08:50:45+00:00
-updated = 2021-04-01T08:50:45+00:00
 draft = false
 +++
 

--- a/themes/adidoks/content/blog/hello-world.md
+++ b/themes/adidoks/content/blog/hello-world.md
@@ -1,8 +1,6 @@
 +++
 title = "Hello World"
 description = "Introducing Doks, a Hugo theme helping you build modern documentation websites that are secure, fast, and SEO-ready — by default."
-date = 2021-05-01T09:19:42+00:00
-updated = 2021-05-01T09:19:42+00:00
 draft = false
 template = "blog/page.html"
 

--- a/themes/adidoks/content/blog/markdown-syntax.md
+++ b/themes/adidoks/content/blog/markdown-syntax.md
@@ -1,8 +1,6 @@
 +++
 title = "Markdown Syntax Guide"
 description = "Sample article showcasing basic Markdown syntax and formatting for HTML elements."
-date = 2021-04-20T09:19:42+00:00
-updated = 2021-04-20T09:19:42+00:00
 draft = false
 template = "blog/page.html"
 
@@ -19,10 +17,15 @@ The following HTML `<h1>`—`<h6>` elements represent six levels of section
 headings. `<h1>` is the highest section level while `<h6>` is the lowest.
 
 # H1
+
 ## H2
+
 ### H3
+
 #### H4
+
 ##### H5
+
 ###### H6
 
 ## Paragraph
@@ -49,47 +52,46 @@ and optionally with in-line changes such as annotations and abbreviations.
 
 #### Blockquote without attribution
 
-> Tiam, ad mint andaepu dandae nostion secatur sequo quae.
-> **Note** that you can use *Markdown syntax* within a blockquote.
+> Tiam, ad mint andaepu dandae nostion secatur sequo quae. **Note** that you can
+> use _Markdown syntax_ within a blockquote.
 
 #### Blockquote with attribution
 
-> Don't communicate by sharing memory, share memory by communicating.<br>
-> — <cite>Rob Pike[^1]</cite>
+> Don't communicate by sharing memory, share memory by communicating.<br> —
+> <cite>Rob Pike[^1]</cite>
 
-> All men by nature desire to know.<br>
-> ― <cite>Aristotle[^2]</cite>
+> All men by nature desire to know.<br> ― <cite>Aristotle[^2]</cite>
 
 ## Tables
 
 Tables aren't part of the core Markdown spec, but Zola supports them
 out-of-the-box.
 
-   Name | Age
---------|------
-    Bob | 27
-  Alice | 23
+| Name  | Age |
+| ----- | --- |
+| Bob   | 27  |
+| Alice | 23  |
 
 #### Inline Markdown within tables
 
 | Italics   | Bold     | Code   |
-| --------  | -------- | ------ |
-| *italics* | **bold** | `code` |
+| --------- | -------- | ------ |
+| _italics_ | **bold** | `code` |
 
 ## Code Blocks
 
 #### Code block with backticks
 
 ```html
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>Example HTML5 Document</title>
-</head>
-<body>
-  <p>Test</p>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Example HTML5 Document</title>
+  </head>
+  <body>
+    <p>Test</p>
+  </body>
 </html>
 ```
 
@@ -145,8 +147,14 @@ Most <mark>salamanders</mark> are nocturnal, and hunt for insects, worms, and
 other small creatures.
 
 ---
-<!-- Note: There must be a blank line between every two lines of the footnote difinition.  -->
-[^1]: The above quote is excerpted from Rob Pike's [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c)
-during Gopherfest, November 18, 2015.
 
-[^2]: The quote is the first sentence of Aristotle's [Metaphysics](http://classics.mit.edu/Aristotle/metaphysics.html).
+<!-- Note: There must be a blank line between every two lines of the footnote difinition.  -->
+
+[^1]:
+    The above quote is excerpted from Rob Pike's
+    [talk](https://www.youtube.com/watch?v=PAAkCSZUG1c) during Gopherfest,
+    November 18, 2015.
+
+[^2]:
+    The quote is the first sentence of Aristotle's
+    [Metaphysics](http://classics.mit.edu/Aristotle/metaphysics.html).

--- a/themes/adidoks/content/blog/math-typesetting.md
+++ b/themes/adidoks/content/blog/math-typesetting.md
@@ -1,8 +1,6 @@
 +++
 title = "Math Typesetting"
 description = "Introducing Doks, a Hugo theme helping you build modern documentation websites that are secure, fast, and SEO-ready — by default."
-date = 2021-04-08T09:19:42+00:00
-updated = 2021-04-08T09:19:42+00:00
 draft = false
 template = "blog/page.html"
 
@@ -14,12 +12,13 @@ lead = "Mathematical notation in a project can be enabled by using third party J
 math = true
 +++
 
-
 In this example we will be using [KaTeX](https://katex.org/)
 
 - Create a macro under `/template/macros/math.html` with a macro named `math`.
-- Within this macro reference the [Auto-render Extension](https://katex.org/docs/autorender.html) or host these scripts locally.
-- Import the macro in your templates like so:  
+- Within this macro reference the
+  [Auto-render Extension](https://katex.org/docs/autorender.html) or host these
+  scripts locally.
+- Import the macro in your templates like so:
 
 ```bash
 {% import 'macros/math.html' as macros %}
@@ -28,13 +27,17 @@ In this example we will be using [KaTeX](https://katex.org/)
 {% endif %}
 ```
 
-- To enable KaTex globally set the parameter `extra.math` to `true` in a project's configuration
-- To enable KaTex on a per page basis include the parameter `extra.math = true` in content files
+- To enable KaTex globally set the parameter `extra.math` to `true` in a
+  project's configuration
+- To enable KaTex on a per page basis include the parameter `extra.math = true`
+  in content files
 
-**Note:** 
+**Note:**
 
-1. The MathJax library is the other optional choice, and you can set the parameter `extra.library` to `mathjax` in a project's configuration
-2. Use the online reference of [Supported TeX Functions](https://katex.org/docs/supported.html)
+1. The MathJax library is the other optional choice, and you can set the
+   parameter `extra.library` to `mathjax` in a project's configuration
+2. Use the online reference of
+   [Supported TeX Functions](https://katex.org/docs/supported.html)
 
 ### Examples
 
@@ -43,6 +46,7 @@ Inline math: \(\varphi = \dfrac{1+\sqrt5}{2}= 1.6180339887…\)
 </p>
 
 Block math:
+
 $$
- \varphi = 1+\frac{1} {1+\frac{1} {1+\frac{1} {1+\cdots} } } 
+ \varphi = 1+\frac{1} {1+\frac{1} {1+\frac{1} {1+\cdots} } }
 $$

--- a/themes/adidoks/content/blog/placeholder-text.md
+++ b/themes/adidoks/content/blog/placeholder-text.md
@@ -1,8 +1,6 @@
 +++
 title = "Placeholder Text"
 description = "Lorem Ipsum Dolor Si Amet"
-date = 2021-04-10T09:19:42+00:00
-updated = 2021-04-10T09:19:42+00:00
 draft = false
 template = "blog/page.html"
 
@@ -23,7 +21,8 @@ cognoscere flos nubis! Fronde ipsamque patulos Dryopen deorum.
 4. Spargitque ferrea quos palude
 
 Rursus nulli murmur; hastile inridet ut ab gravi sententia! Nomine potitus
-silentia flumen, sustinet placuit petis in dilapsa erat sunt. Atria tractus malis.
+silentia flumen, sustinet placuit petis in dilapsa erat sunt. Atria tractus
+malis.
 
 1. Comas hunc haec pietate fetum procerum dixit
 2. Post torum vates letum Tiresia
@@ -41,9 +40,9 @@ silentia flumen, sustinet placuit petis in dilapsa erat sunt. Atria tractus mali
 
 Victa caducifer, malo vulnere contra dicere aurato, ludit regale, voca! Retorsit
 colit est profanae esse virescere furit nec; iaculi matertera et visa est,
-viribus. Divesque creatis, tecta novat collumque vulnus est, parvas.
-**Faces illo pepulere** tempus adest. Tendit flamma, ab opes virum sustinet,
-sidus sequendo urbis.
+viribus. Divesque creatis, tecta novat collumque vulnus est, parvas. **Faces
+illo pepulere** tempus adest. Tendit flamma, ab opes virum sustinet, sidus
+sequendo urbis.
 
 Iubar proles corpore raptos vero auctor imperium; sed et huic: manus caeli
 Lelegas tu lux. Verbis obstitit intus oblectamina fixis linguisque ausus sperare
@@ -52,7 +51,7 @@ ausus; ferebant e primus lora nutat, vici quae mea ipse. Et iter nil spectatae
 vulnus haerentia iuste et exercebat, sui et.
 
 Eurytus Hector, materna ipsumque ut Politen, nec, nate, ignari, vernum cohaesit
-sequitur. Vel **mitis temploque** vocatus, inque alis, *oculos nomen* non silvis
+sequitur. Vel **mitis temploque** vocatus, inque alis, _oculos nomen_ non silvis
 corpore coniunx ne displicet illa. Crescunt non unus, vidit visa quantum inmiti
 flumina mortis facto sic: undique a alios vincula sunt iactata abdita!
 Suspenderat ego fuit tendit: luna, ante urbem Propoetides **parte**.

--- a/themes/adidoks/content/blog/say-hello-to-zola-doks.md
+++ b/themes/adidoks/content/blog/say-hello-to-zola-doks.md
@@ -1,8 +1,6 @@
 +++
 title = "Say hello to AdiDoks 👋"
 description = "Introducing AdiDoks, a Zola theme helping you build modern documentation websites, which is a port of the Hugo theme Doks for Zola."
-date = 2021-04-03T07:00:00+00:00
-updated = 2021-04-03T07:00:00+00:00
 template = "blog/page.html"
 draft = false
 

--- a/themes/adidoks/content/docs/_index.md
+++ b/themes/adidoks/content/docs/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Docs"
 description = "The documents of the AdiDoks theme."
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 sort_by = "weight"
 weight = 1
 template = "docs/section.html"

--- a/themes/adidoks/content/docs/contributing/_index.md
+++ b/themes/adidoks/content/docs/contributing/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Contributing"
 description = "Find out how to contribute to AdiDoks."
-date = 2025-05-01T18:00:00+00:00
-updated = 2021-05-01T18:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 4

--- a/themes/adidoks/content/docs/contributing/code-of-conduct.md
+++ b/themes/adidoks/content/docs/contributing/code-of-conduct.md
@@ -1,8 +1,6 @@
 +++
 title = "Code of Conduct"
 description = "Contributor Covenant Code of Conduct."
-date = 2021-05-01T18:20:00+00:00
-updated = 2021-05-01T18:20:00+00:00
 draft = false
 weight = 420
 sort_by = "weight"
@@ -20,8 +18,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -31,23 +29,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -74,8 +72,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-<aaranxu@outlook.com>.
-All complaints will be reviewed and investigated promptly and fairly.
+<aaranxu@outlook.com>. All complaints will be reviewed and investigated promptly
+and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
@@ -96,15 +94,15 @@ behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
@@ -120,11 +118,11 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
 ## Attribution
 
@@ -132,12 +130,12 @@ This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
-Community Impact Guidelines were inspired by 
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder][Mozilla CoC].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available 
-at [https://www.contributor-covenant.org/translations][translations].
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html

--- a/themes/adidoks/content/docs/contributing/how-to-contribute.md
+++ b/themes/adidoks/content/docs/contributing/how-to-contribute.md
@@ -1,8 +1,6 @@
 +++
 title = "How to Contribute"
 description = "Contribute to AdiDoks, improve documentation, or submit to showcase."
-date = 2021-05-01T18:10:00+00:00
-updated = 2021-05-01T18:10:00+00:00
 draft = false
 weight = 410
 sort_by = "weight"
@@ -18,10 +16,12 @@ top = false
 
 ## Contribute to Doks
 
-👉 The AdiDoks code lives in the [`adidoks` repository](https://github.com/aaranxu/adidoks)
+👉 The AdiDoks code lives in the
+[`adidoks` repository](https://github.com/aaranxu/adidoks)
 
 - Follow the [GitHub flow](https://guides.github.com/introduction/flow/).
-- Follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
+- Follow the
+  [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ### Create an issue
 
@@ -30,8 +30,10 @@ top = false
 
 ## Improve documentation
 
-👉 The documentation lives in [`./content/docs/`](https://github.com/aaranxu/adidoks/tree/master/content/docs)
+👉 The documentation lives in
+[`./content/docs/`](https://github.com/aaranxu/adidoks/tree/master/content/docs)
 of the [`adidoks` repository](https://github.com/h-enk/getdoks.org).
 
 - Follow the [GitHub flow](https://guides.github.com/introduction/flow/).
-- Follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
+- Follow the
+  [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)

--- a/themes/adidoks/content/docs/getting-started/_index.md
+++ b/themes/adidoks/content/docs/getting-started/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Getting Started"
 description = "Quick start and guides for installing the AdiDoks theme on your preferred operating system."
-date = 2025-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 1

--- a/themes/adidoks/content/docs/getting-started/introduction.md
+++ b/themes/adidoks/content/docs/getting-started/introduction.md
@@ -1,8 +1,6 @@
 +++
 title = "Introduction"
 description = "AdiDoks is a Zola theme helping you build modern documentation websites, which is a port of the Hugo theme Doks for Zola."
-date = 2021-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
 draft = false
 weight = 10
 sort_by = "weight"
@@ -16,7 +14,8 @@ top = false
 
 ## Quick Start
 
-One page summary of how to start a new AdiDoks project. [Quick Start →](../quick-start/)
+One page summary of how to start a new AdiDoks project.
+[Quick Start →](../quick-start/)
 
 ## Go further
 
@@ -24,7 +23,8 @@ Contributing and Help.
 
 ## Contributing
 
-Find out how to contribute to Doks. [Contributing →](../../contributing/how-to-contribute/)
+Find out how to contribute to Doks.
+[Contributing →](../../contributing/how-to-contribute/)
 
 ## Help
 

--- a/themes/adidoks/content/docs/getting-started/quick-start.md
+++ b/themes/adidoks/content/docs/getting-started/quick-start.md
@@ -1,8 +1,6 @@
 +++
 title = "Quick Start"
 description = "One page summary of how to start a new AdiDoks project."
-date = 2021-05-01T08:20:00+00:00
-updated = 2021-05-01T08:20:00+00:00
 draft = false
 weight = 20
 sort_by = "weight"
@@ -16,7 +14,9 @@ top = false
 
 ## Requirements
 
-Before using the theme, you need to install the [Zola](https://www.getzola.org/documentation/getting-started/installation/) ≥ 0.15.0.
+Before using the theme, you need to install the
+[Zola](https://www.getzola.org/documentation/getting-started/installation/) ≥
+0.15.0.
 
 ## Run the Theme Directly
 
@@ -90,5 +90,5 @@ Just run `zola serve` in the root path of the project:
 zola serve
 ```
 
-AdiDoks will start the Zola development web server accessible by default at 
+AdiDoks will start the Zola development web server accessible by default at
 `http://127.0.0.1:1111`. Saved changes will live reload in the browser.

--- a/themes/adidoks/content/docs/help/_index.md
+++ b/themes/adidoks/content/docs/help/_index.md
@@ -1,8 +1,6 @@
 +++
 title = "Help"
 description = "Get help on AdiDoks."
-date = 2025-05-01T19:00:00+00:00
-updated = 2021-05-01T19:00:00+00:00
 template = "docs/section.html"
 sort_by = "weight"
 weight = 5

--- a/themes/adidoks/content/docs/help/faq.md
+++ b/themes/adidoks/content/docs/help/faq.md
@@ -1,8 +1,6 @@
 +++
 title = "FAQ"
 description = "Answers to frequently asked questions."
-date = 2021-05-01T19:30:00+00:00
-updated = 2021-05-01T19:30:00+00:00
 draft = false
 weight = 30
 sort_by = "weight"
@@ -17,8 +15,9 @@ top = false
 ## What is the AdiDoks?
 
 AdiDoks is a Zola theme for Documentation's sites, ported by the Hugo Theme
-[Doks](https://getdoks.org), which is a pretty nice theme. Thanks a lot to 
-[*h-enk*](https://github.com/h-enk), the creator of the [Doks](https://getdoks.org).
+[Doks](https://getdoks.org), which is a pretty nice theme. Thanks a lot to
+[_h-enk_](https://github.com/h-enk), the creator of the
+[Doks](https://getdoks.org).
 
 ## Keyboard shortcuts for search?
 
@@ -34,6 +33,6 @@ AdiDoks is a Zola theme for Documentation's sites, ported by the Hugo Theme
 
 ## Contact the creator?
 
-Send *Aaran Xu* an E-mail:
+Send _Aaran Xu_ an E-mail:
 
 - <aaranxu@outlook.com>

--- a/themes/adidoks/content/privacy-policy/_index.md
+++ b/themes/adidoks/content/privacy-policy/_index.md
@@ -1,15 +1,13 @@
 +++
 title = "Privacy Policy"
 description = "We do not use cookies and we do not collect any personal data."
-date = 2021-05-01T08:00:00+00:00
-updated = 2020-05-01T08:00:00+00:00
 draft = false
 
 [extra]
 class = "page single"
 +++
 
-__TLDR__: We do not use cookies and we do not collect any personal data.
+**TLDR**: We do not use cookies and we do not collect any personal data.
 
 ## Website visitors
 


### PR DESCRIPTION
As described in 
https://github.com/getzola/zola/issues/2558

0.19 introduces some breaking changes

We do not lose much by removing the date field as we have history in git, as long as files are not moved